### PR TITLE
Add support for filters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Added support for filters, allowing custom rendering on a per-value basis
+- Added a built-in filter for `reflect.Type`
+
+### Fixed
+
+- Fixed a bug whereby IO errors were not propagated to the caller
+
 ## [0.2.0] - 2019-01-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@
 [![GoDoc](https://godoc.org/github.com/dogmatiq/dapper?status.svg)](https://godoc.org/github.com/dogmatiq/dapper)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dogmatiq/dapper)](https://goreportcard.com/report/github.com/dogmatiq/dapper)
 
-Dapper is a pretty-printer for Go values that aims to produce the shortest
-possible output without ambiguity. Additionally, the output is deterministic,
-which allows for the generation of human-readable diffs using standard tools.
+Dapper is a pretty-printer for Go values.
+
+It is not intended to be used directly as a debugging tool, but as a library
+for applications that need to describe Go values to humans, such as testing
+frameworks.
+
+Some features include:
+
+- Concise formatting, without type ambiguity
+- Deterministic output, useful for generating diffs using standard tools
+- A filtering system for producing customized output on a per-value basis
 
 ## Example
 

--- a/array.go
+++ b/array.go
@@ -1,7 +1,6 @@
 package dapper
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 
@@ -31,8 +30,10 @@ func (vis *visitor) visitArrayValues(w io.Writer, v Value) {
 	for i := 0; i < v.Value.Len(); i++ {
 		elem := v.Value.Index(i)
 
-		if isInterface {
-			fmt.Print("")
+		// unwrap interface values so that elem has it's actual type/kind, and not
+		// that of reflect.Interface.
+		if isInterface && !elem.IsNil() {
+			elem = elem.Elem()
 		}
 
 		vis.visit(

--- a/array.go
+++ b/array.go
@@ -8,7 +8,7 @@ import (
 )
 
 // visitArray formats values with a kind of reflect.Array or Slice.
-func (vis *visitor) visitArray(w io.Writer, v value) {
+func (vis *visitor) visitArray(w io.Writer, v Value) {
 	if v.IsAmbiguousType {
 		vis.write(w, v.TypeName())
 	}
@@ -23,7 +23,7 @@ func (vis *visitor) visitArray(w io.Writer, v value) {
 	vis.write(w, "}")
 }
 
-func (vis *visitor) visitArrayValues(w io.Writer, v value) {
+func (vis *visitor) visitArrayValues(w io.Writer, v Value) {
 	ambiguous := v.Type.Elem().Kind() == reflect.Interface
 
 	for i := 0; i < v.Value.Len(); i++ {

--- a/filter.go
+++ b/filter.go
@@ -2,6 +2,9 @@ package dapper
 
 import (
 	"io"
+	"reflect"
+
+	"github.com/dogmatiq/iago"
 )
 
 // Filter is a function that provides custom formatting logic for specific
@@ -16,3 +19,66 @@ import (
 // Particular attention should be paid to the v.IsUnexported field. If this flag
 // is true, many operations on v.Value are unavailable.
 type Filter func(w io.Writer, v Value) (int, error)
+
+// reflectTypeType is the reflect.Type for reflect.Type itself.
+var reflectTypeType = reflect.TypeOf((*reflect.Type)(nil)).Elem()
+
+// ReflectTypeFilter is a filter that formats reflect.Type values.
+func ReflectTypeFilter(w io.Writer, v Value) (n int, err error) {
+	defer iago.Recover(&err)
+
+	if !v.DynamicType.Implements(reflectTypeType) {
+		return 0, nil
+	}
+
+	if v.DynamicType.Kind() == reflect.Interface && v.Value.IsNil() {
+		return 0, nil
+	}
+
+	var ambiguous bool
+
+	if v.IsAmbiguousStaticType {
+		// always render the type if the static type is ambiguous
+		ambiguous = true
+	} else if v.IsAmbiguousDynamicType {
+		// only consider the dynamic type to be ambiguous if the static type isn't reflect.Type
+		// we're not really concerned with rendering the underlying implementation's type.
+		ambiguous = v.StaticType != reflectTypeType
+	} else {
+		ambiguous = false
+	}
+
+	if ambiguous {
+		n += iago.MustWriteString(w, "reflect.Type(")
+	}
+
+	if v.IsUnexported {
+		n += iago.MustWriteString(w, "<unknown>")
+	} else {
+		t := v.Value.Interface().(reflect.Type)
+
+		if s := t.PkgPath(); s != "" {
+			n += iago.MustWriteString(w, s)
+			n += iago.MustWriteString(w, ".")
+		}
+
+		if s := t.Name(); s != "" {
+			n += iago.MustWriteString(w, s)
+		} else {
+			n += iago.MustWriteString(w, t.String())
+		}
+
+	}
+
+	// always render the pointer value for the type, this way when the field is
+	// unexported we still get something we can compare to known types instead of a
+	// rendering of the reflect.rtype struct.
+	n += iago.MustWriteString(w, " ")
+	n += iago.MustWriteString(w, formatPointerHex(v.Value.Pointer(), false))
+
+	if ambiguous {
+		n += iago.MustWriteString(w, ")")
+	}
+
+	return
+}

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,18 @@
+package dapper
+
+import (
+	"io"
+)
+
+// Filter is a function that provides custom formatting logic for specific
+// values.
+//
+// It writes a formatted representation of v to w, and returns the number of
+// bytes written.
+//
+// If the number of bytes written is non-zero, the default formatting logic is
+// skipped.
+//
+// Particular attention should be paid to the v.IsUnexported field. If this flag
+// is true, many operations on v.Value are unavailable.
+type Filter func(w io.Writer, v Value) (int, error)

--- a/filter.go
+++ b/filter.go
@@ -35,7 +35,7 @@ func ReflectTypeFilter(w io.Writer, v Value) (n int, err error) {
 		return 0, nil
 	}
 
-	var ambiguous bool
+	ambiguous := false
 
 	if v.IsAmbiguousStaticType {
 		// always render the type if the static type is ambiguous
@@ -44,8 +44,6 @@ func ReflectTypeFilter(w io.Writer, v Value) (n int, err error) {
 		// only consider the dynamic type to be ambiguous if the static type isn't reflect.Type
 		// we're not really concerned with rendering the underlying implementation's type.
 		ambiguous = v.StaticType != reflectTypeType
-	} else {
-		ambiguous = false
 	}
 
 	if ambiguous {

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,101 @@
+package dapper_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type reflectType struct {
+	Exported   reflect.Type
+	unexported reflect.Type
+}
+
+var (
+	intType          = reflect.TypeOf(0)
+	intTypePointer   = formatReflectTypePointer(intType)
+	mapType          = reflect.TypeOf(map[string]string{})
+	mapTypePointer   = formatReflectTypePointer(mapType)
+	namedType        = reflect.TypeOf(named{})
+	namedTypePointer = formatReflectTypePointer(namedType)
+)
+
+func formatReflectTypePointer(t reflect.Type) string {
+	return fmt.Sprintf("0x%x", reflect.ValueOf(t).Pointer())
+}
+
+func TestPrinter_ReflectTypeFilter(t *testing.T) {
+	test(
+		t,
+		"built-in type",
+		intType,
+		"reflect.Type(int "+intTypePointer+")",
+	)
+
+	test(
+		t,
+		"built-in parameterized type",
+		mapType,
+		"reflect.Type(map[string]string "+mapTypePointer+")",
+	)
+
+	test(
+		t,
+		"named type",
+		reflect.TypeOf(named{}),
+		"reflect.Type(github.com/dogmatiq/dapper_test.named "+namedTypePointer+")",
+	)
+
+	typ := reflect.TypeOf(struct{ Int int }{})
+	test(
+		t,
+		"anonymous struct",
+		typ,
+		"reflect.Type(struct { Int int } "+formatReflectTypePointer(typ)+")",
+	)
+
+	typ = reflect.TypeOf((*interface{ Int() int })(nil)).Elem()
+	test(
+		t,
+		"anonymous interface",
+		typ,
+		"reflect.Type(interface { Int() int } "+formatReflectTypePointer(typ)+")",
+	)
+
+	test(
+		t,
+		"includes type when in an anonymous struct",
+		struct {
+			Type reflect.Type
+		}{
+			reflect.TypeOf(0),
+		},
+		"{",
+		"    Type: reflect.Type(int "+intTypePointer+")",
+		"}",
+	)
+
+	test(
+		t,
+		"does not include type if static type is also reflect.Type",
+		reflectType{
+			Exported: reflect.TypeOf(0),
+		},
+		"dapper_test.reflectType{",
+		"    Exported:   int "+intTypePointer,
+		"    unexported: nil",
+		"}",
+	)
+
+	test(
+		t,
+		"still renders the pointer address when the value is unexported",
+		reflectType{
+			unexported: reflect.TypeOf(0),
+		},
+		"dapper_test.reflectType{",
+		"    Exported:   nil",
+		"    unexported: <unknown> "+intTypePointer,
+		"}",
+	)
+}

--- a/interface.go
+++ b/interface.go
@@ -5,7 +5,7 @@ import (
 )
 
 // visitInterface formats values with a kind of reflect.Interface.
-func (vis *visitor) visitInterface(w io.Writer, v value) {
+func (vis *visitor) visitInterface(w io.Writer, v Value) {
 	if v.Value.IsNil() {
 		if v.IsAmbiguousType {
 			vis.write(w, v.TypeName())

--- a/interface.go
+++ b/interface.go
@@ -6,31 +6,19 @@ import (
 
 // visitInterface formats values with a kind of reflect.Interface.
 func (vis *visitor) visitInterface(w io.Writer, v Value) {
-	if v.Value.IsNil() {
-		// for a nil interface, we only want to render the type if the STATIC type is
-		// ambigious, since the only information we have available is the interface
-		// type itself, not the actual implementation's type.
-		if v.IsAmbiguousStaticType {
-			vis.write(w, v.TypeName())
-			vis.write(w, "(nil)")
-		} else {
-			vis.write(w, "nil")
-		}
-
-		return
+	if !v.Value.IsNil() {
+		// this should never happen, a more appropraite visit method should have been
+		// chosen based on the value's dynamic type.
+		panic("unexpectedly called visitInterface() with non-nil interface")
 	}
 
-	elem := v.Value.Elem()
-
-	vis.visit(
-		w,
-		Value{
-			Value:                  elem,
-			DynamicType:            elem.Type(),
-			StaticType:             v.DynamicType,
-			IsAmbiguousDynamicType: true,
-			IsAmbiguousStaticType:  v.IsAmbiguousStaticType,
-			IsUnexported:           v.IsUnexported,
-		},
-	)
+	// for a nil interface, we only want to render the type if the STATIC type is
+	// ambigious, since the only information we have available is the interface
+	// type itself, not the actual implementation's type.
+	if v.IsAmbiguousStaticType {
+		vis.write(w, v.TypeName())
+		vis.write(w, "(nil)")
+	} else {
+		vis.write(w, "nil")
+	}
 }

--- a/interface_test.go
+++ b/interface_test.go
@@ -6,10 +6,13 @@ type interfaces struct {
 	Iface interface{}
 }
 
+type iface interface{}
+
 func TestPrinter_Interface(t *testing.T) {
 	// note that capturing a reflect.Value of a nil interface does NOT produces a
 	// value with a "kind" of reflect.Invalid, NOT reflect.Interface.
 	test(t, "nil interface", interface{}(nil), "interface{}(nil)")
+	test(t, "nil named interface", iface(nil), "interface{}(nil)") // interface information is shed when passed to Printer.Write().
 
 	test(
 		t,

--- a/map.go
+++ b/map.go
@@ -39,6 +39,13 @@ func (vis *visitor) visitMapElements(w io.Writer, v Value) {
 
 	for _, mk := range keys {
 		mv := v.Value.MapIndex(mk.Value)
+
+		// unwrap interface values so that elem has it's actual type/kind, and not
+		// that of reflect.Interface.
+		if isInterface && !mv.IsNil() {
+			mv = mv.Elem()
+		}
+
 		vis.write(w, mk.String)
 		vis.write(w, ": ")
 		vis.write(w, strings.Repeat(" ", alignment-mk.Width))
@@ -75,6 +82,13 @@ func (vis *visitor) formatMapKeys(v Value) (keys []mapKey, alignment int) {
 	alignToLastLine := false
 
 	for i, mk := range v.Value.MapKeys() {
+
+		// unwrap interface values so that elem has it's actual type/kind, and not
+		// that of reflect.Interface.
+		if isInterface && !mk.IsNil() {
+			mk = mk.Elem()
+		}
+
 		vis.visit(
 			&w,
 			Value{

--- a/map.go
+++ b/map.go
@@ -12,7 +12,7 @@ import (
 // visitMap formats values with a kind of reflect.Map.
 //
 // TODO(jmalloc): sort numerically-keyed maps numerically
-func (vis *visitor) visitMap(w io.Writer, v value) {
+func (vis *visitor) visitMap(w io.Writer, v Value) {
 	if vis.enter(w, v) {
 		return
 	}
@@ -32,7 +32,7 @@ func (vis *visitor) visitMap(w io.Writer, v value) {
 	vis.write(w, "}")
 }
 
-func (vis *visitor) visitMapElements(w io.Writer, v value) {
+func (vis *visitor) visitMapElements(w io.Writer, v Value) {
 	ambiguous := v.Type.Elem().Kind() == reflect.Interface
 	keys, alignment := vis.formatMapKeys(v)
 
@@ -56,7 +56,7 @@ type mapKey struct {
 // sorted by their string representation.
 //
 // padding is the number of padding characters to add to the shortest key.
-func (vis *visitor) formatMapKeys(v value) (keys []mapKey, alignment int) {
+func (vis *visitor) formatMapKeys(v Value) (keys []mapKey, alignment int) {
 	var w strings.Builder
 	isInterface := v.Type.Key().Kind() == reflect.Interface
 	keys = make([]mapKey, v.Value.Len())

--- a/printer.go
+++ b/printer.go
@@ -95,7 +95,11 @@ func (p *Printer) Format(v interface{}) string {
 }
 
 // defaultPrinter is a Printer instance with default settings.
-var defaultPrinter Printer
+var defaultPrinter = Printer{
+	Filters: []Filter{
+		ReflectTypeFilter,
+	},
+}
 
 // Write writes a pretty-printed representation of v to w using the default
 // printer settings.

--- a/printer.go
+++ b/printer.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/dogmatiq/iago"
 )
 
 const (
@@ -16,15 +18,15 @@ const (
 	DefaultRecursionMarker = "<recursion>"
 )
 
-// defaultPrinter is a Printer instance with default settings.
-var defaultPrinter Printer
-
 // Printer generates human-readable representations of Go values.
 //
 // The output format is intended to be as minimal as possible, without being
 // ambigious. To that end, type information is only included where it can not be
 // reliably inferred from the structure of the value.
 type Printer struct {
+	// Filters is the set of filters to apply when formatting values.
+	Filters []Filter
+
 	// Indent is the string used to indent nested values.
 	// If it is empty, DefaultIndent is used.
 	Indent string
@@ -35,11 +37,17 @@ type Printer struct {
 	RecursionMarker string
 }
 
+// emptyInterfaceType is the reflect.Type for interface{}.
+var emptyInterfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
+
 // Write writes a pretty-printed representation of v to w.
 //
 // It returns the number of bytes written.
-func (p *Printer) Write(w io.Writer, v interface{}) (int, error) {
+func (p *Printer) Write(w io.Writer, v interface{}) (n int, err error) {
+	defer iago.Recover(&err)
+
 	vis := visitor{
+		filters:         p.Filters,
 		indent:          []byte(p.Indent),
 		recursionMarker: p.RecursionMarker,
 	}
@@ -52,9 +60,27 @@ func (p *Printer) Write(w io.Writer, v interface{}) (int, error) {
 		vis.recursionMarker = DefaultRecursionMarker
 	}
 
-	err := vis.visit(w, reflect.ValueOf(v), true)
+	rv := reflect.ValueOf(v)
+	var rt reflect.Type
 
-	return vis.bytes, err
+	if rv.Kind() != reflect.Invalid {
+		rt = rv.Type()
+	}
+
+	vis.visit(
+		w,
+		Value{
+			Value:                  rv,
+			DynamicType:            rt,
+			StaticType:             emptyInterfaceType,
+			IsAmbiguousDynamicType: true,
+			IsAmbiguousStaticType:  true,
+			IsUnexported:           false,
+		},
+	)
+
+	n = vis.bytes
+	return
 }
 
 // Format returns a pretty-printed representation of v.
@@ -67,6 +93,9 @@ func (p *Printer) Format(v interface{}) string {
 
 	return b.String()
 }
+
+// defaultPrinter is a Printer instance with default settings.
+var defaultPrinter Printer
 
 // Write writes a pretty-printed representation of v to w using the default
 // printer settings.

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,10 +1,14 @@
 package dapper_test
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+
 	. "github.com/dogmatiq/dapper"
 )
 
-func ExamplePrint() {
+func ExamplePrinter() {
 	type TreeNode struct {
 		Name     string
 		Value    interface{}
@@ -27,7 +31,9 @@ func ExamplePrint() {
 		},
 	}
 
-	Print(v)
+	p := Printer{}
+	s := p.Format(v)
+	fmt.Println(s)
 
 	// output: dapper_test.TreeNode{
 	//     Name:     "root"
@@ -45,4 +51,29 @@ func ExamplePrint() {
 	//         }
 	//     }
 	// }
+}
+
+func ExamplePrint() {
+	Print(123)
+
+	// output: int(123)
+}
+
+func ExampleFormat() {
+	s := Format(123)
+	fmt.Println(s)
+
+	// output: int(123)
+}
+
+func ExampleWrite() {
+	w := &bytes.Buffer{}
+
+	if _, err := Write(w, 123); err != nil {
+		panic(err)
+	}
+
+	w.WriteTo(os.Stdout)
+
+	// output: int(123)
 }

--- a/ptr.go
+++ b/ptr.go
@@ -22,7 +22,7 @@ func (vis *visitor) visitPtr(w io.Writer, v Value) {
 		Value{
 			Value:                  elem,
 			DynamicType:            elem.Type(),
-			StaticType:             elem.Type(),
+			StaticType:             v.StaticType,
 			IsAmbiguousDynamicType: v.IsAmbiguousDynamicType,
 			IsAmbiguousStaticType:  v.IsAmbiguousStaticType,
 			IsUnexported:           v.IsUnexported,

--- a/ptr.go
+++ b/ptr.go
@@ -5,7 +5,7 @@ import (
 )
 
 // visitPtr formats values with a kind of reflect.Ptr.
-func (vis *visitor) visitPtr(w io.Writer, v value) {
+func (vis *visitor) visitPtr(w io.Writer, v Value) {
 	if vis.enter(w, v) {
 		return
 	}

--- a/ptr.go
+++ b/ptr.go
@@ -11,9 +11,21 @@ func (vis *visitor) visitPtr(w io.Writer, v Value) {
 	}
 	defer vis.leave(v)
 
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, "*")
 	}
 
-	vis.visit(w, v.Value.Elem(), v.IsAmbiguousType)
+	elem := v.Value.Elem()
+
+	vis.visit(
+		w,
+		Value{
+			Value:                  elem,
+			DynamicType:            elem.Type(),
+			StaticType:             elem.Type(),
+			IsAmbiguousDynamicType: false,
+			IsAmbiguousStaticType:  v.IsAmbiguousStaticType,
+			IsUnexported:           v.IsUnexported,
+		},
+	)
 }

--- a/ptr.go
+++ b/ptr.go
@@ -23,7 +23,7 @@ func (vis *visitor) visitPtr(w io.Writer, v Value) {
 			Value:                  elem,
 			DynamicType:            elem.Type(),
 			StaticType:             elem.Type(),
-			IsAmbiguousDynamicType: false,
+			IsAmbiguousDynamicType: v.IsAmbiguousDynamicType,
 			IsAmbiguousStaticType:  v.IsAmbiguousStaticType,
 			IsUnexported:           v.IsUnexported,
 		},

--- a/ptr_test.go
+++ b/ptr_test.go
@@ -2,10 +2,36 @@ package dapper_test
 
 import "testing"
 
+type ptr struct {
+	Value interface{}
+}
+
 func TestPrinter_Ptr(t *testing.T) {
 	value := 100
 	test(t, "nil pointer", (*int)(nil), "*int(nil)")
 	test(t, "non-nil pointer", &value, "*int(100)")
+
+	test(
+		t,
+		"nil pointer inside interface includes element type",
+		ptr{
+			(*int)(nil),
+		},
+		"dapper_test.ptr{",
+		"    Value: *int(nil)",
+		"}",
+	)
+
+	test(
+		t,
+		"non-nil pointer inside interface includes element type",
+		ptr{
+			&value,
+		},
+		"dapper_test.ptr{",
+		"    Value: *int(100)",
+		"}",
+	)
 }
 
 type recursive struct {

--- a/shallow.go
+++ b/shallow.go
@@ -7,7 +7,7 @@ import (
 
 // visitInt formats values with a kind of reflect.Int, and the related
 // fixed-sized types.
-func (vis *visitor) visitInt(w io.Writer, v value) {
+func (vis *visitor) visitInt(w io.Writer, v Value) {
 	if v.IsAmbiguousType {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%v)", v.Value.Int())
@@ -18,7 +18,7 @@ func (vis *visitor) visitInt(w io.Writer, v value) {
 
 // visitUint formats values with a kind of reflect.Uint, and the related
 // fixed-sized types.
-func (vis *visitor) visitUint(w io.Writer, v value) {
+func (vis *visitor) visitUint(w io.Writer, v Value) {
 	if v.IsAmbiguousType {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%v)", v.Value.Uint())
@@ -28,7 +28,7 @@ func (vis *visitor) visitUint(w io.Writer, v value) {
 }
 
 // visitFloat formats values with a kind of reflect.Float32 and Float64.
-func (vis *visitor) visitFloat(w io.Writer, v value) {
+func (vis *visitor) visitFloat(w io.Writer, v Value) {
 	if v.IsAmbiguousType {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%v)", v.Value.Float())
@@ -38,7 +38,7 @@ func (vis *visitor) visitFloat(w io.Writer, v value) {
 }
 
 // visitComplex formats values with a kind of reflect.Complex64 and Complex128.
-func (vis *visitor) visitComplex(w io.Writer, v value) {
+func (vis *visitor) visitComplex(w io.Writer, v Value) {
 	// note that %v formats a complex number already surrounded in parenthesis
 	s := fmt.Sprintf("%v", v.Value.Complex())
 
@@ -51,7 +51,7 @@ func (vis *visitor) visitComplex(w io.Writer, v value) {
 }
 
 // visitUintptr formats values with a kind of reflect.Uintptr.
-func (vis *visitor) visitUintptr(w io.Writer, v value) {
+func (vis *visitor) visitUintptr(w io.Writer, v Value) {
 	s := formatPointerHex(v.Value.Uint(), false)
 
 	if v.IsAmbiguousType {
@@ -63,7 +63,7 @@ func (vis *visitor) visitUintptr(w io.Writer, v value) {
 }
 
 // visitUnsafePointer formats values with a kind of reflect.UnsafePointer.
-func (vis *visitor) visitUnsafePointer(w io.Writer, v value) {
+func (vis *visitor) visitUnsafePointer(w io.Writer, v Value) {
 	s := formatPointerHex(v.Value.Pointer(), true)
 
 	if v.IsAmbiguousType {
@@ -75,7 +75,7 @@ func (vis *visitor) visitUnsafePointer(w io.Writer, v value) {
 }
 
 // visitChan formats values with a kind of reflect.Chan.
-func (vis *visitor) visitChan(w io.Writer, v value) {
+func (vis *visitor) visitChan(w io.Writer, v Value) {
 	if v.IsAmbiguousType {
 		vis.write(w, v.TypeName())
 		vis.write(w, "(")
@@ -101,7 +101,7 @@ func (vis *visitor) visitChan(w io.Writer, v value) {
 }
 
 // visitFunc formats values with a kind of reflect.Func.
-func (vis *visitor) visitFunc(w io.Writer, v value) {
+func (vis *visitor) visitFunc(w io.Writer, v Value) {
 	s := formatPointerHex(v.Value.Pointer(), true)
 
 	if v.IsAmbiguousType {

--- a/shallow.go
+++ b/shallow.go
@@ -3,6 +3,7 @@ package dapper
 import (
 	"fmt"
 	"io"
+	"strconv"
 )
 
 // visitInt formats values with a kind of reflect.Int, and the related
@@ -52,7 +53,7 @@ func (vis *visitor) visitComplex(w io.Writer, v Value) {
 
 // visitUintptr formats values with a kind of reflect.Uintptr.
 func (vis *visitor) visitUintptr(w io.Writer, v Value) {
-	s := formatPointerHex(v.Value.Uint(), false)
+	s := formatPointerHex(uintptr(v.Value.Uint()), false)
 
 	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
@@ -113,16 +114,14 @@ func (vis *visitor) visitFunc(w io.Writer, v Value) {
 }
 
 // formatPointerHex returns a minimal hexadecimal represenation of v.
-func formatPointerHex(v interface{}, zeroIsNil bool) string {
-	s := fmt.Sprintf("%x", v)
-
-	if s == "0" {
+func formatPointerHex(v uintptr, zeroIsNil bool) string {
+	if v == 0 {
 		if zeroIsNil {
 			return "nil"
 		}
 
-		return s
+		return "0"
 	}
 
-	return "0x" + s
+	return "0x" + strconv.FormatUint(uint64(v), 16)
 }

--- a/shallow.go
+++ b/shallow.go
@@ -8,7 +8,7 @@ import (
 // visitInt formats values with a kind of reflect.Int, and the related
 // fixed-sized types.
 func (vis *visitor) visitInt(w io.Writer, v Value) {
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%v)", v.Value.Int())
 	} else {
@@ -19,7 +19,7 @@ func (vis *visitor) visitInt(w io.Writer, v Value) {
 // visitUint formats values with a kind of reflect.Uint, and the related
 // fixed-sized types.
 func (vis *visitor) visitUint(w io.Writer, v Value) {
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%v)", v.Value.Uint())
 	} else {
@@ -29,7 +29,7 @@ func (vis *visitor) visitUint(w io.Writer, v Value) {
 
 // visitFloat formats values with a kind of reflect.Float32 and Float64.
 func (vis *visitor) visitFloat(w io.Writer, v Value) {
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%v)", v.Value.Float())
 	} else {
@@ -42,7 +42,7 @@ func (vis *visitor) visitComplex(w io.Writer, v Value) {
 	// note that %v formats a complex number already surrounded in parenthesis
 	s := fmt.Sprintf("%v", v.Value.Complex())
 
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.write(w, s)
 	} else {
@@ -54,7 +54,7 @@ func (vis *visitor) visitComplex(w io.Writer, v Value) {
 func (vis *visitor) visitUintptr(w io.Writer, v Value) {
 	s := formatPointerHex(v.Value.Uint(), false)
 
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%s)", s)
 	} else {
@@ -66,7 +66,7 @@ func (vis *visitor) visitUintptr(w io.Writer, v Value) {
 func (vis *visitor) visitUnsafePointer(w io.Writer, v Value) {
 	s := formatPointerHex(v.Value.Pointer(), true)
 
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%s)", s)
 	} else {
@@ -76,7 +76,7 @@ func (vis *visitor) visitUnsafePointer(w io.Writer, v Value) {
 
 // visitChan formats values with a kind of reflect.Chan.
 func (vis *visitor) visitChan(w io.Writer, v Value) {
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.write(w, "(")
 	}
@@ -95,7 +95,7 @@ func (vis *visitor) visitChan(w io.Writer, v Value) {
 		)
 	}
 
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, ")")
 	}
 }
@@ -104,7 +104,7 @@ func (vis *visitor) visitChan(w io.Writer, v Value) {
 func (vis *visitor) visitFunc(w io.Writer, v Value) {
 	s := formatPointerHex(v.Value.Pointer(), true)
 
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.writef(w, "(%s)", s)
 	} else {

--- a/slice.go
+++ b/slice.go
@@ -5,7 +5,7 @@ import (
 )
 
 // visitSlice formats values with a kind of reflect.Slice.
-func (vis *visitor) visitSlice(w io.Writer, v value) {
+func (vis *visitor) visitSlice(w io.Writer, v Value) {
 	if vis.enter(w, v) {
 		return
 	}

--- a/struct.go
+++ b/struct.go
@@ -34,6 +34,14 @@ func (vis *visitor) visitStructFields(w io.Writer, v Value) {
 		f := v.DynamicType.Field(i)
 		fv := v.Value.Field(i)
 
+		isInterface := f.Type.Kind() == reflect.Interface
+
+		// unwrap interface values so that elem has it's actual type/kind, and not
+		// that of reflect.Interface.
+		if isInterface && !fv.IsNil() {
+			fv = fv.Elem()
+		}
+
 		vis.write(w, f.Name)
 		vis.write(w, ": ")
 		vis.write(w, strings.Repeat(" ", alignment-len(f.Name)))
@@ -43,7 +51,7 @@ func (vis *visitor) visitStructFields(w io.Writer, v Value) {
 				Value:                  fv,
 				DynamicType:            fv.Type(),
 				StaticType:             f.Type,
-				IsAmbiguousDynamicType: f.Type.Kind() == reflect.Interface,
+				IsAmbiguousDynamicType: isInterface,
 				IsAmbiguousStaticType:  v.IsAmbiguousStaticType && v.IsAnonymousType(),
 				IsUnexported:           v.IsUnexported || isUnexportedField(f),
 			},

--- a/struct.go
+++ b/struct.go
@@ -9,8 +9,8 @@ import (
 )
 
 // visitStruct formats values with a kind of reflect.Struct.
-func (vis *visitor) visitStruct(w io.Writer, v value) {
-	if v.IsAmbiguousType && !v.IsAnonymous() {
+func (vis *visitor) visitStruct(w io.Writer, v Value) {
+	if v.IsAmbiguousType && !v.IsAnonymousType() {
 		vis.write(w, v.TypeName())
 	}
 
@@ -24,9 +24,9 @@ func (vis *visitor) visitStruct(w io.Writer, v value) {
 	vis.write(w, "}")
 }
 
-func (vis *visitor) visitStructFields(w io.Writer, v value) {
+func (vis *visitor) visitStructFields(w io.Writer, v Value) {
 	alignment := longestFieldName(v.Type)
-	anon := v.IsAnonymous()
+	anon := v.IsAnonymousType()
 	var ambiguous bool
 
 	for i := 0; i < v.Type.NumField(); i++ {

--- a/struct.go
+++ b/struct.go
@@ -10,11 +10,14 @@ import (
 
 // visitStruct formats values with a kind of reflect.Struct.
 func (vis *visitor) visitStruct(w io.Writer, v Value) {
-	if v.IsAmbiguousType && !v.IsAnonymousType() {
+	// even if the type is ambiguous, we only render it if it's not anonymous this
+	// is to avoid rendering the full type with field definitions. instead we mark
+	// each field's value as ambiguous and render their types inline.
+	if v.IsAmbiguousType() && !v.IsAnonymousType() {
 		vis.write(w, v.TypeName())
 	}
 
-	if v.Type.NumField() == 0 {
+	if v.DynamicType.NumField() == 0 {
 		vis.write(w, "{}")
 		return
 	}
@@ -25,28 +28,33 @@ func (vis *visitor) visitStruct(w io.Writer, v Value) {
 }
 
 func (vis *visitor) visitStructFields(w io.Writer, v Value) {
-	alignment := longestFieldName(v.Type)
-	anon := v.IsAnonymousType()
-	var ambiguous bool
+	alignment := longestFieldName(v.DynamicType)
 
-	for i := 0; i < v.Type.NumField(); i++ {
-		f := v.Type.Field(i)
+	for i := 0; i < v.DynamicType.NumField(); i++ {
+		f := v.DynamicType.Field(i)
 		fv := v.Value.Field(i)
-
-		if anon {
-			ambiguous = v.IsAmbiguousType
-		} else if f.Type.Kind() == reflect.Interface {
-			ambiguous = !fv.IsNil()
-		} else {
-			ambiguous = false
-		}
 
 		vis.write(w, f.Name)
 		vis.write(w, ": ")
 		vis.write(w, strings.Repeat(" ", alignment-len(f.Name)))
-		vis.visit(w, fv, ambiguous)
+		vis.visit(
+			w,
+			Value{
+				Value:                  fv,
+				DynamicType:            fv.Type(),
+				StaticType:             f.Type,
+				IsAmbiguousDynamicType: f.Type.Kind() == reflect.Interface,
+				IsAmbiguousStaticType:  v.IsAmbiguousStaticType && v.IsAnonymousType(),
+				IsUnexported:           v.IsUnexported || isUnexportedField(f),
+			},
+		)
 		vis.write(w, "\n")
 	}
+}
+
+// isUnxportedField returns true if f is an unexported field.
+func isUnexportedField(f reflect.StructField) bool {
+	return f.PkgPath != ""
 }
 
 // longestFieldName returns the length of the longest field name in a struct.

--- a/value.go
+++ b/value.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// value is a container for a value that can be formatted.
-type value struct {
+// Value contains information about a Go value that is to be formatted.
+type Value struct {
 	// Value is the value to be formatted.
 	Value reflect.Value
 
@@ -21,7 +21,8 @@ type value struct {
 	IsAmbiguousType bool
 }
 
-func (v value) TypeName() string {
+// TypeName returns the name of the value's type formatted for display.
+func (v *Value) TypeName() string {
 	n := v.Type.String()
 	n = strings.Replace(n, "interface {", "interface{", -1)
 
@@ -32,7 +33,7 @@ func (v value) TypeName() string {
 	return n
 }
 
-// IsAnonymous returns true if the value has an anonymous type.
-func (v value) IsAnonymous() bool {
+// IsAnonymousType returns true if the value has an anonymous type.
+func (v *Value) IsAnonymousType() bool {
 	return v.Type.Name() == ""
 }

--- a/value.go
+++ b/value.go
@@ -10,21 +10,35 @@ type Value struct {
 	// Value is the value to be formatted.
 	Value reflect.Value
 
-	// Type is the value's type.
-	Type reflect.Type
+	// DynamicType is the value's type.
+	DynamicType reflect.Type
 
-	// Kind is the value's kind.
-	Kind reflect.Kind
+	// StaticType is the type of the "variable" that the value is stored in, which
+	// may not be the same as its dynamic type.
+	//
+	// For example, when formatting the values within a slice of interface{}
+	// containing integers, such as []interface{}{1, 2, 3}, the DynamicType will be
+	// "int", but the static type will be "interface{}".
+	StaticType reflect.Type
 
-	// IsAmbiguousType is true if the type of v.Value is not clear from what
-	// has already been rendered.
-	IsAmbiguousType bool
+	// IsAmbiguousDynamicType is true if the value's dynamic type is not clear from
+	// the context of what has already been rendered.
+	IsAmbiguousDynamicType bool
+
+	// IsAmbiguousStaticType is true if the value's static type is not clear from
+	// the context of what has already been rendered.
+	IsAmbiguousStaticType bool
+
+	// IsUnexported is true if this value was obtained from an unexported struct
+	// field. If so, it is not possible to extract the underlying value.
+	IsUnexported bool
 }
 
 // TypeName returns the name of the value's type formatted for display.
 func (v *Value) TypeName() string {
-	n := v.Type.String()
+	n := v.DynamicType.String()
 	n = strings.Replace(n, "interface {", "interface{", -1)
+	n = strings.Replace(n, "struct {", "struct{", -1)
 
 	if strings.ContainsAny(n, "() \t\n") {
 		return "(" + n + ")"
@@ -35,5 +49,11 @@ func (v *Value) TypeName() string {
 
 // IsAnonymousType returns true if the value has an anonymous type.
 func (v *Value) IsAnonymousType() bool {
-	return v.Type.Name() == ""
+	return v.DynamicType.Name() == ""
+}
+
+// IsAmbiguousType returns true if either the dynamic type or the static type is
+// ambiguous.
+func (v *Value) IsAmbiguousType() bool {
+	return v.IsAmbiguousDynamicType || v.IsAmbiguousStaticType
 }

--- a/visitor.go
+++ b/visitor.go
@@ -9,6 +9,9 @@ import (
 
 // visitor walks a Go value in order to render it.
 type visitor struct {
+	// filters is the set of filters to apply.
+	filters []Filter
+
 	// indent is the string used to indent nested values.
 	indent []byte
 
@@ -23,22 +26,21 @@ type visitor struct {
 	bytes int
 }
 
-func (vis *visitor) visit(w io.Writer, rv reflect.Value, ambiguous bool) (err error) {
-	defer iago.Recover(&err)
-
-	if rv.Kind() == reflect.Invalid {
+// TODO: don't return err or, let propagate and use iago.Recover() in Printer instead.
+func (vis *visitor) visit(w io.Writer, v Value) {
+	if v.Value.Kind() == reflect.Invalid {
 		vis.write(w, "interface{}(nil)")
 		return
 	}
 
-	v := Value{
-		Value:           rv,
-		Type:            rv.Type(),
-		Kind:            rv.Kind(),
-		IsAmbiguousType: ambiguous,
+	for _, f := range vis.filters {
+		if n := iago.Must(f(w, v)); n > 0 {
+			vis.bytes += n
+			return
+		}
 	}
 
-	switch v.Kind {
+	switch v.DynamicType.Kind() {
 	// type name is not rendered for these types, as the literals are unambiguous.
 	case reflect.String:
 		vis.writef(w, "%#v", v.Value.String())
@@ -102,7 +104,7 @@ func (vis *visitor) enter(w io.Writer, v Value) bool {
 		marker = vis.recursionMarker
 	}
 
-	if v.IsAmbiguousType {
+	if v.IsAmbiguousType() {
 		vis.write(w, v.TypeName())
 		vis.write(w, "(")
 		vis.write(w, marker)

--- a/visitor.go
+++ b/visitor.go
@@ -31,7 +31,7 @@ func (vis *visitor) visit(w io.Writer, rv reflect.Value, ambiguous bool) (err er
 		return
 	}
 
-	v := value{
+	v := Value{
 		Value:           rv,
 		Type:            rv.Type(),
 		Kind:            rv.Kind(),
@@ -83,7 +83,7 @@ func (vis *visitor) visit(w io.Writer, rv reflect.Value, ambiguous bool) (err er
 //
 // It returns true if the value is nil, or recursion has occurred, indicating
 // that the value should not be rendered.
-func (vis *visitor) enter(w io.Writer, v value) bool {
+func (vis *visitor) enter(w io.Writer, v Value) bool {
 	marker := "nil"
 
 	if !v.Value.IsNil() {
@@ -117,7 +117,7 @@ func (vis *visitor) enter(w io.Writer, v value) bool {
 // leave indicates that a potentially recursive value has finished rendering.
 //
 // It must be called after enter(v) returns true.
-func (vis *visitor) leave(v value) {
+func (vis *visitor) leave(v Value) {
 	if !v.Value.IsNil() {
 		delete(vis.recursionSet, v.Value.Pointer())
 	}

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -19,12 +19,18 @@ func test(
 	t.Run(
 		n,
 		func(t *testing.T) {
-			p := Format(v)
+			var w strings.Builder
+			_, err := Write(&w, v)
+
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			t.Log("expected:\n\n" + x + "\n")
 
-			if p != x {
-				t.Fatal("actual:\n\n" + p + "\n")
+			s := w.String()
+			if s != x {
+				t.Fatal("actual:\n\n" + s + "\n")
 			}
 		},
 	)


### PR DESCRIPTION
This PR adds support for user-defined formatting filters.

It also includes a built-in filter that improves the rendering of `reflect.Type` values.

Fixes #1.