### PR TITLE
Implement "unsafe" reflection logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Fixed
+
+- Render `reflect.Type` names when obtained from unexported struct fields ([#9])
+
 ## [0.3.2] - 2019-02-06
 
 ### Changed
@@ -68,6 +74,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 [#6]: https://github.com/dogmatiq/dapper/issues/6
 [#7]: https://github.com/dogmatiq/dapper/issues/7
+[#9]: https://github.com/dogmatiq/dapper/issues/7
 
 [Iago]: https://github.com/dogmatiq/iago
 

--- a/LICENSE.credits
+++ b/LICENSE.credits
@@ -1,0 +1,25 @@
+--------------------------------------------------------------------------------
+
+Spew
+
+    https://github.com/davecgh/go-spew
+
+    Served as the inspiration for the "unsafereflect" package.
+
+License:
+
+    Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+--------------------------------------------------------------------------------

--- a/filter.go
+++ b/filter.go
@@ -65,6 +65,11 @@ func ReflectTypeFilter(w io.Writer, v Value) (n int, err error) {
 			n += must.WriteString(w, t.String())
 		}
 	} else {
+		// CODE COVERAGE: This branch handles a failure within the unsafereflect
+		// package. Ideally this *should* never occur, but is included so as to
+		// avoid a panic on future Go versions. A test within the unsafereflect
+		// package will catch such a failure, at which Dapper will need to be
+		// updated.
 		n += must.WriteString(w, "<unknown>")
 	}
 

--- a/filter.go
+++ b/filter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/dogmatiq/dapper/internal/unsafereflect"
 	"github.com/dogmatiq/iago/must"
 )
 
@@ -50,10 +51,8 @@ func ReflectTypeFilter(w io.Writer, v Value) (n int, err error) {
 		n += must.WriteString(w, "reflect.Type(")
 	}
 
-	if v.IsUnexported {
-		n += must.WriteString(w, "<unknown>")
-	} else {
-		t := v.Value.Interface().(reflect.Type)
+	if mv, ok := unsafereflect.MakeMutable(v.Value); ok {
+		t := mv.Interface().(reflect.Type)
 
 		if s := t.PkgPath(); s != "" {
 			n += must.WriteString(w, s)
@@ -65,6 +64,8 @@ func ReflectTypeFilter(w io.Writer, v Value) (n int, err error) {
 		} else {
 			n += must.WriteString(w, t.String())
 		}
+	} else {
+		n += must.WriteString(w, "<unknown>")
 	}
 
 	// always render the pointer value for the type, this way when the field is

--- a/filter_test.go
+++ b/filter_test.go
@@ -79,23 +79,12 @@ func TestPrinter_ReflectTypeFilter(t *testing.T) {
 		t,
 		"does not include type if static type is also reflect.Type",
 		reflectType{
-			Exported: reflect.TypeOf(0),
-		},
-		"dapper_test.reflectType{",
-		"    Exported:   int "+intTypePointer,
-		"    unexported: nil",
-		"}",
-	)
-
-	test(
-		t,
-		"still renders the pointer address when the value is unexported",
-		reflectType{
+			Exported:   reflect.TypeOf(0),
 			unexported: reflect.TypeOf(0),
 		},
 		"dapper_test.reflectType{",
-		"    Exported:   nil",
-		"    unexported: <unknown> "+intTypePointer,
+		"    Exported:   int "+intTypePointer,
+		"    unexported: int "+intTypePointer,
 		"}",
 	)
 }

--- a/interface.go
+++ b/interface.go
@@ -9,8 +9,8 @@ import (
 // visitInterface formats values with a kind of reflect.Interface.
 func (vis *visitor) visitInterface(w io.Writer, v Value) {
 	if !v.Value.IsNil() {
-		// this should never happen, a more appropraite visit method should have been
-		// chosen based on the value's dynamic type.
+		// CODE COVERAGE: this should never happen, a more appropriate visit
+		// method should have been chosen based on the value's dynamic type.
 		panic("unexpectedly called visitInterface() with non-nil interface")
 	}
 

--- a/internal/unsafereflect/value.go
+++ b/internal/unsafereflect/value.go
@@ -1,0 +1,128 @@
+package unsafereflect
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+// MakeMutable returns a copy of v with read-only restrictions removed.
+//
+// This allows invocation of methods on the value. Care must be taken not to
+// call methods that modify the returned value.
+//
+// It returns false if the value can not be made mutable.
+func MakeMutable(v reflect.Value) (reflect.Value, bool) {
+	if v.CanInterface() {
+		return v, true
+	}
+
+	if flagsErr != nil {
+		return v, false
+	}
+
+	f := flags(&v)
+	*f &^= flagRO // clear the read-only flag
+
+	return v, true
+}
+
+// flag is defined equivalently to the unexported reflect.flag type.
+type flag uintptr
+
+// The following constants are defined equivalently to their respective
+// counterparts in the reflect package.
+const (
+	flagStickyRO flag = 1 << 5
+	flagEmbedRO  flag = 1 << 6
+	flagRO       flag = flagStickyRO | flagEmbedRO
+)
+
+var (
+	// flagOffset is the offset of the "flag" field within the reflect.Value type.
+	flagOffset uintptr
+
+	// flagsErr is non-nil if there is a problem verifying the values of
+	// internal reflection flags.
+	flagsErr error
+)
+
+// flags returns a pointer to the "flag" field of *v.
+func flags(v *reflect.Value) *flag {
+	return (*flag)(
+		unsafe.Pointer(
+			uintptr(unsafe.Pointer(v)) + flagOffset,
+		),
+	)
+}
+
+// computeFlagOffset checks for the presence of the "flag" field within the
+// reflect.Value type and returns its offset.
+func computeFlagOffset() (uintptr, error) {
+	rt := reflect.TypeOf(reflect.Value{})
+
+	// Ensure that reflect.Value even has a "flag" field.
+	f, ok := rt.FieldByName("flag")
+	if !ok {
+		return 0, errors.New("reflect.Value has no flag field")
+	}
+
+	// Ensure that the type of "reflect.flag" is compatible with our local
+	// definition.
+	k := reflect.TypeOf(flagRO).Kind()
+	if f.Type.Kind() != k {
+		return 0, fmt.Errorf("reflect.Value flag is not a %s", k)
+	}
+
+	return f.Offset, nil
+}
+
+// checkFlagValues verifies that the locally defined flag values match those
+// produced by the reflect package.
+func checkFlagValues() error {
+	// Create a test type containing a combination of exported, unexported and
+	// embedded fields. These are used to guess the flag values to ensure or
+	// local definitions are correct.
+	type t struct{}
+	var v struct {
+		Exported   t
+		unexported t // unexported, flagStickyRO will be set
+		t            // embedded, flagEmbedRO will be set
+	}
+
+	rv := reflect.ValueOf(v)
+
+	var (
+		exported        = rv.FieldByName("Exported")
+		exportedFlags   = *flags(&exported)
+		unexported      = rv.FieldByName("unexported")
+		unexportedFlags = *flags(&unexported)
+		embedded        = rv.FieldByName("t")
+		embeddedFlags   = *flags(&embedded)
+	)
+
+	// Take the difference between the flags of the exported field, and the
+	// flags of the fields that are known to be "read-only" to deduce the value
+	// of the "flagRO" constant.
+	deducedFlagRO := exportedFlags ^ (unexportedFlags | embeddedFlags)
+
+	if flagRO != deducedFlagRO {
+		return fmt.Errorf(
+			"flagRO is defined as %v, but the actual value is likely %v",
+			flagRO,
+			deducedFlagRO,
+		)
+	}
+
+	return nil
+}
+
+func init() {
+	flagOffset, flagsErr = computeFlagOffset()
+	if flagsErr != nil {
+		return
+	}
+
+	flagsErr = checkFlagValues()
+}

--- a/internal/unsafereflect/value.go
+++ b/internal/unsafereflect/value.go
@@ -19,6 +19,8 @@ func MakeMutable(v reflect.Value) (reflect.Value, bool) {
 	}
 
 	if flagsErr != nil {
+		// CODE COVERAGE: This branch is never executed unless the internals of
+		// the reflect package have changed in some incompatible way.
 		return v, false
 	}
 
@@ -65,6 +67,8 @@ func computeFlagOffset() (uintptr, error) {
 	// Ensure that reflect.Value even has a "flag" field.
 	f, ok := rt.FieldByName("flag")
 	if !ok {
+		// CODE COVERAGE: This branch is never executed unless the internals of
+		// the reflect package have changed in some incompatible way.
 		return 0, errors.New("reflect.Value has no flag field")
 	}
 
@@ -72,6 +76,8 @@ func computeFlagOffset() (uintptr, error) {
 	// definition.
 	k := reflect.TypeOf(flagRO).Kind()
 	if f.Type.Kind() != k {
+		// CODE COVERAGE: This branch is never executed unless the internals of
+		// the reflect package have changed in some incompatible way.
 		return 0, fmt.Errorf("reflect.Value flag is not a %s", k)
 	}
 
@@ -108,6 +114,8 @@ func checkFlagValues() error {
 	deducedFlagRO := exportedFlags ^ (unexportedFlags | embeddedFlags)
 
 	if flagRO != deducedFlagRO {
+		// CODE COVERAGE: This branch is never executed unless the internals of
+		// the reflect package have changed in some incompatible way.
 		return fmt.Errorf(
 			"flagRO is defined as %v, but the actual value is likely %v",
 			flagRO,
@@ -121,6 +129,8 @@ func checkFlagValues() error {
 func init() {
 	flagOffset, flagsErr = computeFlagOffset()
 	if flagsErr != nil {
+		// CODE COVERAGE: This branch is never executed unless the internals of
+		// the reflect package have changed in some incompatible way.
 		return
 	}
 

--- a/internal/unsafereflect/value_test.go
+++ b/internal/unsafereflect/value_test.go
@@ -1,0 +1,44 @@
+package unsafereflect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMakeMutable_exported_field(t *testing.T) {
+	var v struct {
+		F int
+	}
+
+	rv := reflect.ValueOf(v)
+	rf := rv.FieldByName("F")
+
+	mv, ok := MakeMutable(rf)
+
+	if !ok {
+		t.Fatal("ok != true")
+	}
+
+	mv.Interface() // will panic if restrictions are not removed
+}
+
+func TestMakeMutable_unexported_field(t *testing.T) {
+	var v struct {
+		f int
+	}
+
+	rv := reflect.ValueOf(v)
+	rf := rv.FieldByName("f")
+
+	if mv, ok := MakeMutable(rf); ok {
+		mv.Interface() // will panic if restrictions are not removed
+	}
+}
+
+// This test will fail if the internals of the reflect package have changed such
+// that the "read-only" flag value is no longer known.
+func TestFlags(t *testing.T) {
+	if flagsErr != nil {
+		t.Fatal(flagsErr)
+	}
+}

--- a/printer.go
+++ b/printer.go
@@ -91,6 +91,8 @@ func (p *Printer) Format(v interface{}) string {
 	var b strings.Builder
 
 	if _, err := p.Write(&b, v); err != nil {
+		// CODE COVERAGE: At the time of writing, strings.Builder.Write() never
+		// returns an error.
 		panic(err)
 	}
 


### PR DESCRIPTION
This allows invocation of methods on `reflect.Value` instances that were obtained from unexported struct fields.

Fixes #9