### PR TITLE
Render human-readable states for various sync types.

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -118,6 +118,7 @@ var defaultPrinter = Printer{
 		ReflectTypeFilter,
 		TimeFilter,
 		DurationFilter,
+		SyncFilter,
 	},
 }
 

--- a/sync.go
+++ b/sync.go
@@ -1,0 +1,154 @@
+package dapper
+
+import (
+	"io"
+	"reflect"
+	"sync"
+
+	"github.com/dogmatiq/iago/must"
+)
+
+var (
+	// mutexType is the reflect.Type for the sync.Mutex type.
+	mutexType = reflect.TypeOf((*sync.Mutex)(nil)).Elem()
+
+	// rwMutexType is the reflect.Type for the sync.RWMutex type.
+	rwMutexType = reflect.TypeOf((*sync.RWMutex)(nil)).Elem()
+
+	// onceType is the reflect.Type for the sync.Once type.
+	onceType = reflect.TypeOf((*sync.Once)(nil)).Elem()
+)
+
+// SyncFilter is a filter that formats various types from the sync package.
+func SyncFilter(w io.Writer, v Value) (int, error) {
+	switch v.DynamicType {
+	case mutexType:
+		return mutexFilter(w, v)
+	case rwMutexType:
+		return rwMutexFilter(w, v)
+	case onceType:
+		return onceFilter(w, v)
+	default:
+		return 0, nil
+	}
+}
+
+func mutexFilter(w io.Writer, v Value) (n int, err error) {
+	defer must.Recover(&err)
+
+	state := v.Value.FieldByName("state")
+
+	s := "<unlocked>"
+	if !isInt(state) {
+		// CODE COVERAGE: This branch handles the case when the internals of the
+		// sync package have changed. Ideally this *should* never occur, but is
+		// included so as to avoid a panic on future versions of the sync
+		// package. The tests will catch such a failure, at which point Dapper
+		// will need to be updated.
+		s = "<unknown state>"
+	} else if state.Int() != 0 {
+		s = "<locked>"
+	}
+
+	if v.IsAmbiguousType() {
+		n += must.WriteString(w, v.TypeName())
+		n += must.Fprintf(w, "(%v)", s)
+	} else {
+		n += must.Fprintf(w, "%v", s)
+	}
+
+	return
+}
+
+func rwMutexFilter(w io.Writer, v Value) (n int, err error) {
+	defer must.Recover(&err)
+
+	wait := v.Value.FieldByName("readerWait")
+	count := v.Value.FieldByName("readerCount")
+	write := v.Value.FieldByName("w")
+
+	var state reflect.Value
+	if write.Kind() == reflect.Struct {
+		state = write.FieldByName("state")
+	}
+
+	s := "<unlocked>"
+	if !isInt(wait) ||
+		!isInt(count) ||
+		!isInt(state) {
+		// CODE COVERAGE: This branch handles the case when the internals of the
+		// sync package have changed. Ideally this *should* never occur, but is
+		// included so as to avoid a panic on future versions of the sync
+		// package. The tests will catch such a failure, at which point Dapper
+		// will need to be updated.
+		s = "<unknown state>"
+	} else if wait.Int() > 0 || count.Int() > 0 {
+		s = "<read locked>"
+	} else if state.Int() != 0 {
+		s = "<write locked>"
+	}
+
+	if v.IsAmbiguousType() {
+		n += must.WriteString(w, v.TypeName())
+		n += must.Fprintf(w, "(%v)", s)
+	} else {
+		n += must.Fprintf(w, "%v", s)
+	}
+
+	return
+}
+
+func onceFilter(w io.Writer, v Value) (n int, err error) {
+	defer must.Recover(&err)
+
+	done := v.Value.FieldByName("done")
+
+	s := "<pending>"
+	if !isUint(done) {
+		// CODE COVERAGE: This branch handles the case when the internals of the
+		// sync package have changed. Ideally this *should* never occur, but is
+		// included so as to avoid a panic on future versions of the sync
+		// package. The tests will catch such a failure, at which point Dapper
+		// will need to be updated.
+		s = "<unknown state>"
+	} else if done.Uint() != 0 {
+		s = "<complete>"
+	}
+
+	if v.IsAmbiguousType() {
+		n += must.WriteString(w, v.TypeName())
+		n += must.Fprintf(w, "(%v)", s)
+	} else {
+		n += must.Fprintf(w, "%v", s)
+	}
+
+	return
+}
+
+// isInt returns true if v is one of the signed integer types.
+func isInt(v reflect.Value) bool {
+	ok := false
+	switch v.Kind() {
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		ok = true
+	}
+	return ok
+}
+
+// isUint returns true if v is one of the unsigned integer types.
+func isUint(v reflect.Value) bool {
+	ok := false
+	switch v.Kind() {
+	case reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64:
+		ok = true
+	}
+	return ok
+}

--- a/sync.go
+++ b/sync.go
@@ -38,7 +38,7 @@ func mutexFilter(w io.Writer, v Value) (n int, err error) {
 
 	state := v.Value.FieldByName("state")
 
-	s := "<unknoen state>"
+	s := "<unknown state>"
 	if isInt(state) {
 		if state.Int() != 0 {
 			s = "<locked>"

--- a/sync.go
+++ b/sync.go
@@ -38,16 +38,13 @@ func mutexFilter(w io.Writer, v Value) (n int, err error) {
 
 	state := v.Value.FieldByName("state")
 
-	s := "<unlocked>"
-	if !isInt(state) {
-		// CODE COVERAGE: This branch handles the case when the internals of the
-		// sync package have changed. Ideally this *should* never occur, but is
-		// included so as to avoid a panic on future versions of the sync
-		// package. The tests will catch such a failure, at which point Dapper
-		// will need to be updated.
-		s = "<unknown state>"
-	} else if state.Int() != 0 {
-		s = "<locked>"
+	s := "<unknoen state>"
+	if isInt(state) {
+		if state.Int() != 0 {
+			s = "<locked>"
+		} else {
+			s = "<unlocked>"
+		}
 	}
 
 	if v.IsAmbiguousType() {
@@ -72,20 +69,15 @@ func rwMutexFilter(w io.Writer, v Value) (n int, err error) {
 		state = write.FieldByName("state")
 	}
 
-	s := "<unlocked>"
-	if !isInt(wait) ||
-		!isInt(count) ||
-		!isInt(state) {
-		// CODE COVERAGE: This branch handles the case when the internals of the
-		// sync package have changed. Ideally this *should* never occur, but is
-		// included so as to avoid a panic on future versions of the sync
-		// package. The tests will catch such a failure, at which point Dapper
-		// will need to be updated.
-		s = "<unknown state>"
-	} else if wait.Int() > 0 || count.Int() > 0 {
-		s = "<read locked>"
-	} else if state.Int() != 0 {
-		s = "<write locked>"
+	s := "<unknown state>"
+	if isInt(wait) && isInt(count) && isInt(state) {
+		if wait.Int() > 0 || count.Int() > 0 {
+			s = "<read locked>"
+		} else if state.Int() != 0 {
+			s = "<write locked>"
+		} else {
+			s = "<unlocked>"
+		}
 	}
 
 	if v.IsAmbiguousType() {
@@ -103,16 +95,13 @@ func onceFilter(w io.Writer, v Value) (n int, err error) {
 
 	done := v.Value.FieldByName("done")
 
-	s := "<pending>"
-	if !isUint(done) {
-		// CODE COVERAGE: This branch handles the case when the internals of the
-		// sync package have changed. Ideally this *should* never occur, but is
-		// included so as to avoid a panic on future versions of the sync
-		// package. The tests will catch such a failure, at which point Dapper
-		// will need to be updated.
-		s = "<unknown state>"
-	} else if done.Uint() != 0 {
-		s = "<complete>"
+	s := "<unknown state>"
+	if isUint(done) {
+		if done.Uint() != 0 {
+			s = "<complete>"
+		} else {
+			s = "<pending>"
+		}
 	}
 
 	if v.IsAmbiguousType() {

--- a/sync_test.go
+++ b/sync_test.go
@@ -1,0 +1,109 @@
+package dapper_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPrinter_SyncFilter(t *testing.T) {
+	var w sync.Mutex
+
+	test(
+		t,
+		"sync.Mutex (unlocked)",
+		&w, // use pointer to avoid copy
+		"*sync.Mutex(<unlocked>)",
+	)
+
+	w.Lock()
+	test(
+		t,
+		"sync.Mutex (locked)",
+		&w, // use pointer to avoid copy
+		"*sync.Mutex(<locked>)",
+	)
+	w.Unlock()
+
+	var rw sync.RWMutex
+
+	test(
+		t,
+		"sync.RWMutex (unlocked)",
+		&rw, // use pointer to avoid copy
+		"*sync.RWMutex(<unlocked>)",
+	)
+
+	rw.Lock()
+	test(
+		t,
+		"sync.RWMutex (write locked)",
+		&rw, // use pointer to avoid copy
+		"*sync.RWMutex(<write locked>)",
+	)
+	rw.Unlock()
+
+	rw.RLock()
+	test(
+		t,
+		"sync.RWMutex (read locked)",
+		&rw, // use pointer to avoid copy
+		"*sync.RWMutex(<read locked>)",
+	)
+	rw.RUnlock()
+
+	rw.RLock()
+	rw.RLock()
+	barrier := make(chan struct{})
+	go func() {
+		barrier <- struct{}{}
+		rw.Lock()
+		barrier <- struct{}{}
+	}()
+	<-barrier
+
+	time.Sleep(100 * time.Millisecond)
+
+	test(
+		t,
+		"sync.RWMutex (read locked, write lock pending)",
+		&rw, // use pointer to avoid copy
+		"*sync.RWMutex(<read locked>)",
+	)
+	rw.RUnlock()
+	rw.RUnlock()
+	<-barrier
+	rw.Unlock()
+
+	var o sync.Once
+	test(
+		t,
+		"sync.Mutex (pending)",
+		&o, // use pointer to avoid copy
+		"*sync.Once(<pending>)",
+	)
+
+	o.Do(func() {})
+	test(
+		t,
+		"sync.Once (complete)",
+		&o, // use pointer to avoid copy
+		"*sync.Once(<complete>)",
+	)
+
+	type syncTypes struct {
+		w    sync.Mutex
+		rw   sync.RWMutex
+		once sync.Once
+	}
+	test(
+		t,
+		"excludes type information if it is not ambiguous",
+		syncTypes{},
+		"dapper_test.syncTypes{",
+		"    w:    <unlocked>",
+		"    rw:   <unlocked>",
+		"    once: <pending>",
+		"}",
+	)
+}


### PR DESCRIPTION
- `sync.Mutex`
- `sync.RWMutex`
- `sync.Once`

Fixes #14.