### PR TITLE
Render byte-slices and byte-arrays using hexdump.

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -23,6 +23,27 @@ func TestPrinter_Array(t *testing.T) {
 	)
 }
 
+// This test verifies that byte arrays are rendered using hexdump format.
+func TestPrinter_ByteArray(t *testing.T) {
+	data := []byte("Hello, world!\nThis is some sample text which includes some non-printable characters like '\x00'.")
+	var array [93]byte
+	copy(array[:], data)
+
+	test(
+		t,
+		"byte slice",
+		array,
+		"[93]uint8{",
+		"    00000000  48 65 6c 6c 6f 2c 20 77  6f 72 6c 64 21 0a 54 68  |Hello, world!.Th|",
+		"    00000010  69 73 20 69 73 20 73 6f  6d 65 20 73 61 6d 70 6c  |is is some sampl|",
+		"    00000020  65 20 74 65 78 74 20 77  68 69 63 68 20 69 6e 63  |e text which inc|",
+		"    00000030  6c 75 64 65 73 20 73 6f  6d 65 20 6e 6f 6e 2d 70  |ludes some non-p|",
+		"    00000040  72 69 6e 74 61 62 6c 65  20 63 68 61 72 61 63 74  |rintable charact|",
+		"    00000050  65 72 73 20 6c 69 6b 65  20 27 00 27 2e           |ers like '.'.|",
+		"}",
+	)
+}
+
 // This test verifies the formatting of array values when the type
 // information omitted because it can be inferred from the context in which the
 // values are rendered.

--- a/slice_test.go
+++ b/slice_test.go
@@ -25,6 +25,23 @@ func TestPrinter_Slice(t *testing.T) {
 	)
 }
 
+// This test verifies that byte slices are rendered using hexdump format.
+func TestPrinter_ByteSlice(t *testing.T) {
+	test(
+		t,
+		"byte slice",
+		[]byte("Hello, world!\nThis is some sample text which includes some non-printable characters like '\x00'."),
+		"[]uint8{",
+		"    00000000  48 65 6c 6c 6f 2c 20 77  6f 72 6c 64 21 0a 54 68  |Hello, world!.Th|",
+		"    00000010  69 73 20 69 73 20 73 6f  6d 65 20 73 61 6d 70 6c  |is is some sampl|",
+		"    00000020  65 20 74 65 78 74 20 77  68 69 63 68 20 69 6e 63  |e text which inc|",
+		"    00000030  6c 75 64 65 73 20 73 6f  6d 65 20 6e 6f 6e 2d 70  |ludes some non-p|",
+		"    00000040  72 69 6e 74 61 62 6c 65  20 63 68 61 72 61 63 74  |rintable charact|",
+		"    00000050  65 72 73 20 6c 69 6b 65  20 27 00 27 2e           |ers like '.'.|",
+		"}",
+	)
+}
+
 // This test verifies the formatting of slice values when the type
 // information omitted because it can be inferred from the context in which the
 // values are rendered.


### PR DESCRIPTION
Fixes #15.