### PR TITLE
Not align map values after multiline keys

### DIFF
--- a/map.go
+++ b/map.go
@@ -49,7 +49,12 @@ func (vis *visitor) visitMapElements(w io.Writer, v Value) {
 
 		must.WriteString(w, mk.String)
 		must.WriteString(w, ": ")
-		must.WriteString(w, strings.Repeat(" ", alignment-mk.Width))
+
+		// align values only if the key fits in a single line
+		if !strings.ContainsRune(mk.String, '\n') {
+			must.WriteString(w, strings.Repeat(" ", alignment-mk.Width))
+		}
+
 		vis.visit(
 			w,
 			Value{

--- a/map_test.go
+++ b/map_test.go
@@ -119,7 +119,7 @@ func TestPrinter_MultilineMapKeyAlignment(t *testing.T) {
 		`    "the longest key in the galaxy": "two"`,
 		"    dapper_test.multiline{",
 		`        Key: "multiline key"`,
-		`    }:                               "three"`,
+		`    }: "three"`,
 		"}",
 	)
 
@@ -134,7 +134,7 @@ func TestPrinter_MultilineMapKeyAlignment(t *testing.T) {
 		`    "short":                 "one"`,
 		"    dapper_test.multiline{",
 		`        Key: "multiline key"`,
-		`    }:                       "three"`,
+		`    }: "three"`,
 		"}",
 	)
 }


### PR DESCRIPTION
This PR changes the map output as follows:

- If a map key is printed out on multiple lines, the proceeding value is not aligned with the values that follow single-line keys.

For example:

Previous logic would print out the map with the multiline keys as follows:

```
map[interface{}]string{
     "short":                         "one"
     "the longest key in the galaxy": "two"
     dapper_test.multiline{
         Key: "multiline key"
     }:                               "three"
}
```
the modified logic prints the identical map as follows:

```
map[interface{}]string{
     "short":                         "one"
     "the longest key in the galaxy": "two"
     dapper_test.multiline{
         Key: "multiline key"
     }: "three"
}
```

Fixes #4.