### PR TITLE
Add sync.Map rendering filter.

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -17,6 +17,9 @@ var (
 
 	// onceType is the reflect.Type for the sync.Once type.
 	onceType = reflect.TypeOf((*sync.Once)(nil)).Elem()
+
+	// mapType is the reflect.Type for the sync.Map type.
+	mapType = reflect.TypeOf((*sync.Map)(nil)).Elem()
 )
 
 // SyncFilter is a filter that formats various types from the sync package.

--- a/sync.go
+++ b/sync.go
@@ -26,7 +26,7 @@ var (
 func SyncFilter(
 	w io.Writer,
 	v Value,
-	_ Config,
+	c Config,
 	p FilterPrinter,
 ) error {
 	switch v.DynamicType {
@@ -36,6 +36,8 @@ func SyncFilter(
 		return rwMutexFilter(w, v, p)
 	case onceType:
 		return onceFilter(w, v, p)
+	case mapType:
+		return mapFilter(w, v, c, p)
 	default:
 		return nil
 	}

--- a/syncmap.go
+++ b/syncmap.go
@@ -74,7 +74,7 @@ func (m *syncMapItems) populate(
 			Value{
 				Value:                  k,
 				DynamicType:            k.Type(),
-				StaticType:             k.Type(),
+				StaticType:             emptyInterfaceType,
 				IsAmbiguousDynamicType: true,
 				IsAmbiguousStaticType:  false,
 				IsUnexported:           parent.IsUnexported,
@@ -101,7 +101,7 @@ func (m *syncMapItems) populate(
 			Value{
 				Value:                  v,
 				DynamicType:            v.Type(),
-				StaticType:             v.Type(),
+				StaticType:             emptyInterfaceType,
 				IsAmbiguousDynamicType: true,
 				IsAmbiguousStaticType:  false,
 				IsUnexported:           parent.IsUnexported,

--- a/syncmap.go
+++ b/syncmap.go
@@ -34,7 +34,7 @@ func mapFilter(
 			var sb strings.Builder
 			kv := reflect.ValueOf(key)
 
-			if err = p.Write(
+			p.Write(
 				&sb,
 				Value{
 					Value:                  kv,
@@ -44,9 +44,7 @@ func mapFilter(
 					IsAmbiguousStaticType:  false,
 					IsUnexported:           v.IsUnexported,
 				},
-			); err != nil {
-				return false
-			}
+			)
 
 			ks := sb.String()
 
@@ -60,7 +58,7 @@ func mapFilter(
 
 			vv := reflect.ValueOf(val)
 
-			if err = p.Write(
+			p.Write(
 				&sb,
 				Value{
 					Value:                  vv,
@@ -70,9 +68,7 @@ func mapFilter(
 					IsAmbiguousStaticType:  false,
 					IsUnexported:           v.IsUnexported,
 				},
-			); err != nil {
-				return false
-			}
+			)
 
 			vs := sb.String()
 
@@ -87,9 +83,6 @@ func mapFilter(
 			return true
 		},
 	)
-	if err != nil {
-		return err
-	}
 
 	if len(items) == 0 {
 		must.WriteString(w, "{}")

--- a/syncmap.go
+++ b/syncmap.go
@@ -13,6 +13,7 @@ import (
 func mapFilter(
 	w io.Writer,
 	v Value,
+	c Config,
 	f func(w io.Writer, v Value) error,
 ) (err error) {
 	defer must.Recover(&err)

--- a/syncmap.go
+++ b/syncmap.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/dogmatiq/iago/indent"
 	"github.com/dogmatiq/iago/must"
@@ -21,17 +22,14 @@ func mapFilter(
 	if v.IsAmbiguousType() {
 		must.WriteString(w, v.TypeName())
 	}
-	if v.Value.IsZero() {
-		must.WriteString(w, "{}")
-		return
-	}
 
 	i := syncMapItems{}
-	if v.Value.Addr().MethodByName("Range").Call(
-		[]reflect.Value{
-			reflect.ValueOf(i.populate(v, f)),
-		},
-	); i.Err != nil {
+
+	v.Value.Addr().Interface().(*sync.Map).Range(
+		i.populate(v, f),
+	)
+
+	if i.Err != nil {
 		return i.Err
 	}
 

--- a/syncmap.go
+++ b/syncmap.go
@@ -1,0 +1,17 @@
+package dapper
+
+import (
+	"io"
+
+	"github.com/dogmatiq/iago/must"
+)
+
+func mapFilter(w io.Writer, v Value) (n int, err error) {
+	defer must.Recover(&err)
+
+	if v.DynamicType != mapType {
+		return 0, nil
+	}
+
+	return 0, nil
+}

--- a/syncmap.go
+++ b/syncmap.go
@@ -2,16 +2,170 @@ package dapper
 
 import (
 	"io"
+	"reflect"
+	"sort"
+	"strings"
 
+	"github.com/dogmatiq/iago/indent"
 	"github.com/dogmatiq/iago/must"
 )
 
-func mapFilter(w io.Writer, v Value) (n int, err error) {
+func mapFilter(
+	w io.Writer,
+	v Value,
+	f func(w io.Writer, v Value) error,
+) (err error) {
 	defer must.Recover(&err)
 
-	if v.DynamicType != mapType {
-		return 0, nil
+	if v.IsAmbiguousType() {
+		must.WriteString(w, v.TypeName())
+	}
+	if v.Value.IsZero() {
+		must.WriteString(w, "{}")
+		return
 	}
 
-	return 0, nil
+	i := syncMapItems{}
+	if v.Value.Addr().MethodByName("Range").Call(
+		[]reflect.Value{
+			reflect.ValueOf(i.populate(v, f)),
+		},
+	); i.Err != nil {
+		return i.Err
+	}
+
+	if len(i.Items) == 0 {
+		must.WriteString(w, "{}")
+		return
+	}
+
+	must.WriteString(w, "{\n")
+
+	i.print(
+		// TO-DO(danilvpetrov): inject the indenter into the filter, rather than
+		// hardcoding the indentation. Probably a 'Formatter' interface should
+		// be created that would look something like this:
+		//
+		// type Formatter interface {
+		//		Format(w io.Writer, v Value) error
+		// 		Indenter() io.Writer
+		// }
+		//
+		// Then, we could pass it as a third argument to all filters instead of
+		// f func(w io.Writer, v Value) error.
+		indent.NewIndenter(w, []byte("    ")),
+		f,
+	)
+
+	must.WriteString(w, "}")
+
+	return
+}
+
+type syncMapItem struct {
+	KeyWidth    int
+	KeyString   string
+	ValueString string
+}
+
+type syncMapItems struct {
+	Alignment int
+	Items     []syncMapItem
+	Err       error
+
+	alignToLastLine bool
+}
+
+func (m *syncMapItems) populate(
+	parent Value,
+	format func(w io.Writer, v Value) error,
+) func(interface{}, interface{}) bool {
+	return func(key, val interface{}) bool {
+		var w strings.Builder
+		k := reflect.ValueOf(key)
+
+		if err := format(
+			&w,
+			Value{
+				Value:                  k,
+				DynamicType:            k.Type(),
+				StaticType:             k.Type(),
+				IsAmbiguousDynamicType: true,
+				IsAmbiguousStaticType:  false,
+				IsUnexported:           parent.IsUnexported,
+			},
+		); err != nil {
+			m.Err = err
+			return false
+		}
+
+		ks := w.String()
+
+		max, last := widths(ks)
+		if max > m.Alignment {
+			m.Alignment = max
+			m.alignToLastLine = max == last
+		}
+
+		w.Reset()
+
+		v := reflect.ValueOf(val)
+
+		if err := format(
+			&w,
+			Value{
+				Value:                  v,
+				DynamicType:            v.Type(),
+				StaticType:             v.Type(),
+				IsAmbiguousDynamicType: true,
+				IsAmbiguousStaticType:  false,
+				IsUnexported:           parent.IsUnexported,
+			},
+		); err != nil {
+			m.Err = err
+			return false
+		}
+
+		vs := w.String()
+
+		m.Items = append(
+			m.Items,
+			syncMapItem{
+				KeyString:   ks,
+				KeyWidth:    last,
+				ValueString: vs,
+			},
+		)
+		return true
+	}
+}
+
+func (m *syncMapItems) print(
+	w io.Writer,
+	format func(w io.Writer, v Value) error,
+) {
+	sort.Slice(
+		m.Items,
+		func(i, j int) bool {
+			return m.Items[i].KeyString < m.Items[j].KeyString
+		},
+	)
+
+	// compensate for the ":" added to the last line"
+	if !m.alignToLastLine {
+		m.Alignment--
+	}
+
+	for _, item := range m.Items {
+		must.WriteString(w, item.KeyString)
+		must.WriteString(w, ": ")
+
+		// align values only if the key fits in a single line
+		if !strings.ContainsRune(item.KeyString, '\n') {
+			must.WriteString(w, strings.Repeat(" ", m.Alignment-item.KeyWidth))
+		}
+
+		must.WriteString(w, item.ValueString)
+		must.WriteString(w, "\n")
+	}
 }

--- a/syncmap.go
+++ b/syncmap.go
@@ -43,18 +43,7 @@ func mapFilter(
 	must.WriteString(w, "{\n")
 
 	i.print(
-		// TO-DO(danilvpetrov): inject the indenter into the filter, rather than
-		// hardcoding the indentation. Probably a 'Formatter' interface should
-		// be created that would look something like this:
-		//
-		// type Formatter interface {
-		//		Format(w io.Writer, v Value) error
-		// 		Indenter() io.Writer
-		// }
-		//
-		// Then, we could pass it as a third argument to all filters instead of
-		// f func(w io.Writer, v Value) error.
-		indent.NewIndenter(w, []byte("    ")),
+		indent.NewIndenter(w, c.Indent),
 		f,
 	)
 

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -1,40 +1,51 @@
 package dapper_test
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
 	"sync"
 	"testing"
+
+	. "github.com/dogmatiq/dapper"
 )
 
 type syncmaps struct {
 	Map sync.Map
 }
 
-// This test verifies that that sync.Map key/value types are rendered when
-// they can be inferred from the context.
+// This test verifies that that sync.Map key/value types are always rendered.
 func TestPrinter_SyncMap(t *testing.T) {
 	var m sync.Map
 
-	test(t, "empty sync.SyncMap", &m, "*sync.Map{}")
+	test(t, "zero-value sync.Map", &m, "*sync.Map{}")
 
 	m.Store(1, 100)
 	m.Store(2, 200)
 
 	test(
 		t,
-		"*sync.SyncMap",
+		"sync.Map",
 		&m,
-		"*sync.SyncMap{",
+		"*sync.Map{",
 		"    int(1): int(100)",
 		"    int(2): int(200)",
 		"}",
 	)
+
+	m.Delete(1)
+	m.Delete(2)
+
+	test(t, "empty sync.Map", &m, "*sync.Map{}")
 }
 
 // This test verifies the formatting of sync.Map key/values in the named structs.
 func TestPrinter_SyncMapInNamedStruct(t *testing.T) {
 	test(
 		t,
-		"empty sync.Map in named struct",
+		"empty sync.Map",
 		&syncmaps{},
 		"*dapper_test.syncmaps{",
 		"    Map: {}",
@@ -48,10 +59,10 @@ func TestPrinter_SyncMapInNamedStruct(t *testing.T) {
 
 	test(
 		t,
-		"instances of *sync.Map in named struct",
+		"non-empty sync.Map",
 		sm,
-		"dapper_test.syncmaps{",
-		"    Map:               {",
+		"*dapper_test.syncmaps{",
+		"    Map: {",
 		"        int(1): int(100)",
 		"        int(2): int(200)",
 		"    }",
@@ -65,15 +76,15 @@ func TestPrinter_SyncMapKeySorting(t *testing.T) {
 	var m sync.Map
 
 	m.Store("foo", 1)
-	m.Store("bar", 200)
+	m.Store("bar", 2)
 
 	test(
 		t,
 		"keys are sorted by their string representation",
 		&m,
-		"*sync.SyncMap{",
-		`    "bar": 2`,
-		`    "foo": 1`,
+		"*sync.Map{",
+		`    "bar": int(2)`,
+		`    "foo": int(1)`,
 		"}",
 	)
 }
@@ -91,7 +102,7 @@ func TestPrinter_MultilineSyncMapKeyAlignment(t *testing.T) {
 		t,
 		"keys are aligned correctly",
 		&m,
-		"*sync.SyncMap{",
+		"*sync.Map{",
 		`    "short":                         "one"`,
 		`    "the longest key in the galaxy": "two"`,
 		"    dapper_test.multiline{",
@@ -106,7 +117,7 @@ func TestPrinter_MultilineSyncMapKeyAlignment(t *testing.T) {
 		t,
 		"keys are aligned correctly when the longest line is part of a multiline key",
 		&m,
-		"*sync.SyncMap{",
+		"*sync.Map{",
 		`    "short":                 "one"`,
 		"    dapper_test.multiline{",
 		`        Key: "multiline key"`,
@@ -125,8 +136,54 @@ func TestPrinter_SyncMapRecursion(t *testing.T) {
 		t,
 		"recursive sync.Map",
 		&m,
-		"*sync.SyncMap{",
-		`    "child": *sync.SyncMap{}(<recursion>)`,
+		"*sync.Map{",
+		`    "child": *sync.Map(<recursion>)`,
 		"}",
+	)
+}
+
+// This test verifies that recursive sync.Map is detected, and do not produce
+// an infinite loop or stack overflow.
+func TestPrinter_SyncMapFormatFunctionErr(t *testing.T) {
+	m := &sync.Map{}
+	m.Store("foo", 1)
+
+	v := Value{
+		Value:                  reflect.ValueOf(m).Elem(),
+		DynamicType:            reflect.TypeOf(m).Elem(),
+		StaticType:             reflect.TypeOf(m).Elem(),
+		IsAmbiguousDynamicType: false,
+		IsAmbiguousStaticType:  false,
+		IsUnexported:           false,
+	}
+
+	terr := errors.New("test key format function error")
+	err := SyncFilter(
+		&strings.Builder{},
+		v,
+		func(_ io.Writer, v Value) error {
+			if s, ok := v.Value.Interface().(string); ok && s == "foo" {
+				return terr
+			}
+			return nil
+		},
+	)
+
+	t.Log(fmt.Sprintf("expected:\n\n%v\n", terr))
+
+	if terr != err {
+		t.Fatal(fmt.Sprintf("actual:\n\n%v\n", err))
+	}
+
+	terr = errors.New("test value format function error")
+	err = SyncFilter(
+		&strings.Builder{},
+		v,
+		func(_ io.Writer, v Value) error {
+			if i, ok := v.Value.Interface().(int); ok && i == 1 {
+				return terr
+			}
+			return nil
+		},
 	)
 }

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 type syncmaps struct {
-	Map sync.Map
+	Map   sync.Map
+	Force bool
 }
 
 // This test verifies that that sync.Map key/value types are always rendered.
@@ -41,8 +42,11 @@ func TestPrinter_SyncMapInNamedStruct(t *testing.T) {
 	test(
 		t,
 		"empty sync.Map",
-		&syncmaps{},
-		"*github.com/dogmatiq/dapper_test.syncmaps{<zero>}",
+		&syncmaps{Force: true},
+		"*github.com/dogmatiq/dapper_test.syncmaps{",
+		"    Map:   {}",
+		"    Force: true",
+		"}",
 	)
 
 	sm := &syncmaps{}
@@ -55,10 +59,11 @@ func TestPrinter_SyncMapInNamedStruct(t *testing.T) {
 		"non-empty sync.Map",
 		sm,
 		"*github.com/dogmatiq/dapper_test.syncmaps{",
-		"    Map: {",
+		"    Map:   {",
 		"        int(1): int(100)",
 		"        int(2): int(200)",
 		"    }",
+		"    Force: false",
 		"}",
 	)
 }

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -1,11 +1,8 @@
 package dapper_test
 
 import (
-	"io"
 	"sync"
 	"testing"
-
-	. "github.com/dogmatiq/dapper"
 )
 
 type syncmaps struct {
@@ -134,26 +131,4 @@ func TestPrinter_SyncMapRecursion(t *testing.T) {
 		`    "child": *sync.Map(<recursion>)`,
 		"}",
 	)
-}
-
-// testFilterPrinter is the test implementation of FilterPrinter interface.
-type testFilterPrinter struct {
-	WriteFn          func(io.Writer, Value) error
-	FormatTypeNameFn func(Value) string
-}
-
-func (t *testFilterPrinter) Write(w io.Writer, v Value) error {
-	if t.WriteFn == nil {
-		return nil
-	}
-
-	return t.WriteFn(w, v)
-}
-
-func (t *testFilterPrinter) FormatTypeName(v Value) string {
-	if t.FormatTypeNameFn == nil {
-		return ""
-	}
-
-	return t.FormatTypeNameFn(v)
 }

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -20,7 +20,7 @@ type syncmaps struct {
 func TestPrinter_SyncMap(t *testing.T) {
 	var m sync.Map
 
-	test(t, "zero-value sync.Map", &m, "*sync.Map{}")
+	test(t, "empty sync.Map", &m, "*sync.Map{}")
 
 	m.Store(1, 100)
 	m.Store(2, 200)
@@ -34,11 +34,6 @@ func TestPrinter_SyncMap(t *testing.T) {
 		"    int(2): int(200)",
 		"}",
 	)
-
-	m.Delete(1)
-	m.Delete(2)
-
-	test(t, "empty sync.Map", &m, "*sync.Map{}")
 }
 
 // This test verifies the formatting of sync.Map key/values in the named structs.

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -119,7 +119,7 @@ func TestPrinter_MultilineSyncMapKeyAlignment(t *testing.T) {
 	)
 }
 
-// This test verifies that recursive sync.Map is detected, and do not produce
+// This test verifies that recursive sync.Map is detected, and does not produce
 // an infinite loop or stack overflow.
 func TestPrinter_SyncMapRecursion(t *testing.T) {
 	var m sync.Map

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -161,6 +161,7 @@ func TestPrinter_SyncMapFormatFunctionErr(t *testing.T) {
 	err := SyncFilter(
 		&strings.Builder{},
 		v,
+		Config{},
 		func(_ io.Writer, v Value) error {
 			if s, ok := v.Value.Interface().(string); ok && s == "foo" {
 				return terr
@@ -179,6 +180,7 @@ func TestPrinter_SyncMapFormatFunctionErr(t *testing.T) {
 	err = SyncFilter(
 		&strings.Builder{},
 		v,
+		Config{},
 		func(_ io.Writer, v Value) error {
 			if i, ok := v.Value.Interface().(int); ok && i == 1 {
 				return terr

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -7,7 +7,7 @@ import (
 
 type syncmaps struct {
 	Map   sync.Map
-	Force bool
+	Force bool // prevent rendering of the zero-value marker
 }
 
 // This test verifies that that sync.Map key/value types are always rendered.

--- a/syncmap_test.go
+++ b/syncmap_test.go
@@ -1,0 +1,132 @@
+package dapper_test
+
+import (
+	"sync"
+	"testing"
+)
+
+type syncmaps struct {
+	Map sync.Map
+}
+
+// This test verifies that that sync.Map key/value types are rendered when
+// they can be inferred from the context.
+func TestPrinter_SyncMap(t *testing.T) {
+	var m sync.Map
+
+	test(t, "empty sync.SyncMap", &m, "*sync.Map{}")
+
+	m.Store(1, 100)
+	m.Store(2, 200)
+
+	test(
+		t,
+		"*sync.SyncMap",
+		&m,
+		"*sync.SyncMap{",
+		"    int(1): int(100)",
+		"    int(2): int(200)",
+		"}",
+	)
+}
+
+// This test verifies the formatting of sync.Map key/values in the named structs.
+func TestPrinter_SyncMapInNamedStruct(t *testing.T) {
+	test(
+		t,
+		"empty sync.Map in named struct",
+		&syncmaps{},
+		"*dapper_test.syncmaps{",
+		"    Map: {}",
+		"}",
+	)
+
+	sm := &syncmaps{}
+
+	sm.Map.Store(1, 100)
+	sm.Map.Store(2, 200)
+
+	test(
+		t,
+		"instances of *sync.Map in named struct",
+		sm,
+		"dapper_test.syncmaps{",
+		"    Map:               {",
+		"        int(1): int(100)",
+		"        int(2): int(200)",
+		"    }",
+		"}",
+	)
+}
+
+// This test verifies that sync.Map keys are sorted by their formatted string
+// representation.
+func TestPrinter_SyncMapKeySorting(t *testing.T) {
+	var m sync.Map
+
+	m.Store("foo", 1)
+	m.Store("bar", 200)
+
+	test(
+		t,
+		"keys are sorted by their string representation",
+		&m,
+		"*sync.SyncMap{",
+		`    "bar": 2`,
+		`    "foo": 1`,
+		"}",
+	)
+}
+
+// This test verifies that values associated with sync.Map keys that have a
+// multiline string representation are aligned correctly.
+func TestPrinter_MultilineSyncMapKeyAlignment(t *testing.T) {
+	var m sync.Map
+
+	m.Store("short", "one")
+	m.Store("the longest key in the galaxy", "two")
+	m.Store(multiline{Key: "multiline key"}, "three")
+
+	test(
+		t,
+		"keys are aligned correctly",
+		&m,
+		"*sync.SyncMap{",
+		`    "short":                         "one"`,
+		`    "the longest key in the galaxy": "two"`,
+		"    dapper_test.multiline{",
+		`        Key: "multiline key"`,
+		`    }: "three"`,
+		"}",
+	)
+
+	m.Delete("the longest key in the galaxy")
+
+	test(
+		t,
+		"keys are aligned correctly when the longest line is part of a multiline key",
+		&m,
+		"*sync.SyncMap{",
+		`    "short":                 "one"`,
+		"    dapper_test.multiline{",
+		`        Key: "multiline key"`,
+		`    }: "three"`,
+		"}",
+	)
+}
+
+// This test verifies that recursive sync.Map is detected, and do not produce
+// an infinite loop or stack overflow.
+func TestPrinter_SyncMapRecursion(t *testing.T) {
+	var m sync.Map
+	m.Store("child", &m)
+
+	test(
+		t,
+		"recursive sync.Map",
+		&m,
+		"*sync.SyncMap{",
+		`    "child": *sync.SyncMap{}(<recursion>)`,
+		"}",
+	)
+}


### PR DESCRIPTION
This PR adds a rendering filter for `sync.Map` type. 

The goal is to keep the most of `sync.Map` rendering consistent with Go's regular maps.