### PR TITLE
Relocate recursion detection logic.

### DIFF
--- a/map.go
+++ b/map.go
@@ -14,6 +14,11 @@ import (
 //
 // TODO(jmalloc): sort numerically-keyed maps numerically
 func (vis *visitor) visitMap(w io.Writer, v Value) {
+	if v.Value.IsNil() {
+		vis.renderNil(w, v)
+		return
+	}
+
 	if v.IsAmbiguousType() {
 		must.WriteString(w, v.TypeName())
 	}

--- a/map.go
+++ b/map.go
@@ -14,11 +14,6 @@ import (
 //
 // TODO(jmalloc): sort numerically-keyed maps numerically
 func (vis *visitor) visitMap(w io.Writer, v Value) {
-	if vis.enter(w, v) {
-		return
-	}
-	defer vis.leave(v)
-
 	if v.IsAmbiguousType() {
 		must.WriteString(w, v.TypeName())
 	}

--- a/ptr.go
+++ b/ptr.go
@@ -8,6 +8,11 @@ import (
 
 // visitPtr formats values with a kind of reflect.Ptr.
 func (vis *visitor) visitPtr(w io.Writer, v Value) {
+	if v.Value.IsNil() {
+		vis.renderNil(w, v)
+		return
+	}
+
 	if v.IsAmbiguousType() {
 		must.WriteByte(w, '*')
 	}

--- a/ptr.go
+++ b/ptr.go
@@ -8,11 +8,6 @@ import (
 
 // visitPtr formats values with a kind of reflect.Ptr.
 func (vis *visitor) visitPtr(w io.Writer, v Value) {
-	if vis.enter(w, v) {
-		return
-	}
-	defer vis.leave(v)
-
 	if v.IsAmbiguousType() {
 		must.WriteByte(w, '*')
 	}

--- a/slice.go
+++ b/slice.go
@@ -6,5 +6,10 @@ import (
 
 // visitSlice formats values with a kind of reflect.Slice.
 func (vis *visitor) visitSlice(w io.Writer, v Value) {
+	if v.Value.IsNil() {
+		vis.renderNil(w, v)
+		return
+	}
+
 	vis.visitArray(w, v)
 }

--- a/slice.go
+++ b/slice.go
@@ -6,10 +6,5 @@ import (
 
 // visitSlice formats values with a kind of reflect.Slice.
 func (vis *visitor) visitSlice(w io.Writer, v Value) {
-	if vis.enter(w, v) {
-		return
-	}
-	defer vis.leave(v)
-
 	vis.visitArray(w, v)
 }

--- a/value.go
+++ b/value.go
@@ -58,12 +58,12 @@ func (v *Value) IsAmbiguousType() bool {
 	return v.IsAmbiguousDynamicType || v.IsAmbiguousStaticType
 }
 
-// canNil reports if v.Value can be nil. When this method returns true, it is
-// safe to call IsNil() on the value without causing panicking.
-func (v *Value) canNil() bool {
+// canPointer reports if v.Value.Pointer() method can be called without
+// panicking.
+func (v *Value) canPointer() bool {
 	switch v.DynamicType.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface,
-		reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+	case reflect.Chan, reflect.Func, reflect.Map,
+		reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
 		return true
 	default:
 		return false

--- a/value.go
+++ b/value.go
@@ -57,3 +57,16 @@ func (v *Value) IsAnonymousType() bool {
 func (v *Value) IsAmbiguousType() bool {
 	return v.IsAmbiguousDynamicType || v.IsAmbiguousStaticType
 }
+
+// CanNil reports if the Value can be nil as a zero value. When this method
+// returns true, it is safe to call IsNil() on the value without causing
+// panicking.
+func (v *Value) CanNil() bool {
+	switch v.DynamicType.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface,
+		reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return true
+	default:
+		return false
+	}
+}

--- a/value.go
+++ b/value.go
@@ -58,10 +58,9 @@ func (v *Value) IsAmbiguousType() bool {
 	return v.IsAmbiguousDynamicType || v.IsAmbiguousStaticType
 }
 
-// CanNil reports if v.Value can be nil. When this method
-// returns true, it is safe to call IsNil() on the value without causing
-// panicking.
-func (v *Value) CanNil() bool {
+// canNil reports if v.Value can be nil. When this method returns true, it is
+// safe to call IsNil() on the value without causing panicking.
+func (v *Value) canNil() bool {
 	switch v.DynamicType.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface,
 		reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:

--- a/value.go
+++ b/value.go
@@ -58,7 +58,7 @@ func (v *Value) IsAmbiguousType() bool {
 	return v.IsAmbiguousDynamicType || v.IsAmbiguousStaticType
 }
 
-// CanNil reports if the Value can be nil as a zero value. When this method
+// CanNil reports if v.Value can be nil. When this method
 // returns true, it is safe to call IsNil() on the value without causing
 // panicking.
 func (v *Value) CanNil() bool {

--- a/visitor.go
+++ b/visitor.go
@@ -120,7 +120,7 @@ func (vis *visitor) leave(v Value) {
 	}
 }
 
-// renderNil renders the given Value as if it is nil.
+// renderNil renders a nil value of any type.
 func (vis *visitor) renderNil(w io.Writer, v Value) {
 	if v.IsAmbiguousType() {
 		must.WriteString(w, fmt.Sprintf("%s(nil)", v.TypeName()))

--- a/visitor.go
+++ b/visitor.go
@@ -84,7 +84,7 @@ func (vis *visitor) visit(w io.Writer, v Value) {
 // It returns true if the value is nil, or recursion has occurred, indicating
 // that the value should not be rendered.
 func (vis *visitor) enter(w io.Writer, v Value) bool {
-	if !v.CanNil() {
+	if !v.canNil() {
 		return false
 	}
 
@@ -128,7 +128,7 @@ func (vis *visitor) enter(w io.Writer, v Value) bool {
 //
 // It must be called after enter(v) returns true.
 func (vis *visitor) leave(v Value) {
-	if v.CanNil() && !v.Value.IsNil() {
+	if v.canNil() && !v.Value.IsNil() {
 		delete(vis.recursionSet, v.Value.Pointer())
 	}
 }


### PR DESCRIPTION
This PR removes the  recursion detection logic from `visitor.visitMap()`, `visitor.visitPtr()`, and `visitor.visitSlice()` methods and places it on the top of `visitor.visit()` method to have a single point of recursion detection and recursion marker printing. 

This PR is a precursor to #26 as `sync.Map` filter requires recursion detection when rendering `sync.Map` elements. 