### PR TITLE
Inject visitor to filters.

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -12,83 +12,80 @@ import (
 )
 
 func TestPrinter_Filter(t *testing.T) {
-	t.Run("format function", testFormatFunction)
-	t.Run("filter fails with error", testFilterFailingWithErr)
-}
-
-func testFormatFunction(t *testing.T) {
-	type testType struct {
-		i int
-	}
-
-	tt := testType{
-		i: 100,
-	}
-
-	f := func(
-		w io.Writer,
-		v Value,
-		f func(w io.Writer, v Value) error,
-	) error {
-		if v.TypeName() == "dapper_test.testType" {
-			must.WriteString(w, "dapper_test.testType<")
-
-			fv := v.Value.FieldByName("i")
-
-			if err := f(
-				w,
-				Value{
-					Value:                  fv,
-					DynamicType:            fv.Type(),
-					StaticType:             fv.Type(),
-					IsAmbiguousDynamicType: false,
-					IsAmbiguousStaticType:  false,
-					IsUnexported:           true,
-				},
-			); err != nil {
-				return err
-			}
-
-			must.WriteByte(w, '>')
+	t.Run("format function", func(t *testing.T) {
+		type testType struct {
+			i int
 		}
-		return nil
-	}
 
-	p := Printer{
-		Filters: []Filter{f},
-	}
+		tt := testType{
+			i: 100,
+		}
 
-	expected := fmt.Sprintf("dapper_test.testType<%d>", tt.i)
-	t.Log("expected:\n\n" + expected + "\n")
+		f := func(
+			w io.Writer,
+			v Value,
+			f func(w io.Writer, v Value) error,
+		) error {
+			if v.TypeName() == "dapper_test.testType" {
+				must.WriteString(w, "dapper_test.testType<")
 
-	actual := p.Format(tt)
-	if actual != expected {
-		t.Fatal("actual:\n\n" + actual + "\n")
-	}
-}
+				fv := v.Value.FieldByName("i")
 
-func testFilterFailingWithErr(t *testing.T) {
-	var (
-		err  error
-		terr = errors.New("test filter error")
-	)
+				if err := f(
+					w,
+					Value{
+						Value:                  fv,
+						DynamicType:            fv.Type(),
+						StaticType:             fv.Type(),
+						IsAmbiguousDynamicType: false,
+						IsAmbiguousStaticType:  false,
+						IsUnexported:           true,
+					},
+				); err != nil {
+					return err
+				}
 
-	f := func(
-		w io.Writer,
-		v Value,
-		f func(w io.Writer, v Value) error,
-	) error {
-		return terr
-	}
+				must.WriteByte(w, '>')
+			}
+			return nil
+		}
 
-	p := Printer{
-		Filters: []Filter{f},
-	}
+		p := Printer{
+			Filters: []Filter{f},
+		}
 
-	t.Log("expected:\n\n" + fmt.Sprintf("%#+v", terr) + "\n")
+		expected := fmt.Sprintf("dapper_test.testType<%d>", tt.i)
+		t.Log("expected:\n\n" + expected + "\n")
 
-	_, err = p.Write(&strings.Builder{}, 100)
-	if err != terr {
-		t.Log("actual:\n\n" + fmt.Sprintf("%#+v", err) + "\n")
-	}
+		actual := p.Format(tt)
+		if actual != expected {
+			t.Fatal("actual:\n\n" + actual + "\n")
+		}
+	})
+
+	t.Run("filter errors are propagated", func(t *testing.T) {
+		var (
+			err  error
+			terr = errors.New("test filter error")
+		)
+
+		f := func(
+			w io.Writer,
+			v Value,
+			f func(w io.Writer, v Value) error,
+		) error {
+			return terr
+		}
+
+		p := Printer{
+			Filters: []Filter{f},
+		}
+
+		t.Log("expected:\n\n" + fmt.Sprintf("%#+v", terr) + "\n")
+
+		_, err = p.Write(&strings.Builder{}, 100)
+		if err != terr {
+			t.Log("actual:\n\n" + fmt.Sprintf("%#+v", err) + "\n")
+		}
+	})
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,94 @@
+package dapper_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	. "github.com/dogmatiq/dapper"
+	"github.com/dogmatiq/iago/must"
+)
+
+func TestPrinter_Filter(t *testing.T) {
+	t.Run("format function", testFormatFunction)
+	t.Run("filter fails with error", testFilterFailingWithErr)
+}
+
+func testFormatFunction(t *testing.T) {
+	type testType struct {
+		i int
+	}
+
+	tt := testType{
+		i: 100,
+	}
+
+	f := func(
+		w io.Writer,
+		v Value,
+		f func(w io.Writer, v Value) error,
+	) error {
+		if v.TypeName() == "dapper_test.testType" {
+			must.WriteString(w, "dapper_test.testType<")
+
+			fv := v.Value.FieldByName("i")
+
+			if err := f(
+				w,
+				Value{
+					Value:                  fv,
+					DynamicType:            fv.Type(),
+					StaticType:             fv.Type(),
+					IsAmbiguousDynamicType: false,
+					IsAmbiguousStaticType:  false,
+					IsUnexported:           true,
+				},
+			); err != nil {
+				return err
+			}
+
+			must.WriteByte(w, '>')
+		}
+		return nil
+	}
+
+	p := Printer{
+		Filters: []Filter{f},
+	}
+
+	expected := fmt.Sprintf("dapper_test.testType<%d>", tt.i)
+	t.Log("expected:\n\n" + expected + "\n")
+
+	actual := p.Format(tt)
+	if actual != expected {
+		t.Fatal("actual:\n\n" + actual + "\n")
+	}
+}
+
+func testFilterFailingWithErr(t *testing.T) {
+	var (
+		err  error
+		terr = errors.New("test filter error")
+	)
+
+	f := func(
+		w io.Writer,
+		v Value,
+		f func(w io.Writer, v Value) error,
+	) error {
+		return terr
+	}
+
+	p := Printer{
+		Filters: []Filter{f},
+	}
+
+	t.Log("expected:\n\n" + fmt.Sprintf("%#+v", terr) + "\n")
+
+	_, err = p.Write(&strings.Builder{}, 100)
+	if err != terr {
+		t.Log("actual:\n\n" + fmt.Sprintf("%#+v", err) + "\n")
+	}
+}

--- a/printer.go
+++ b/printer.go
@@ -14,23 +14,27 @@ const (
 	// DefaultIndent is the default indent string used to indent nested values.
 	DefaultIndent = "    "
 
-	// DefaultRecursionMarker is the default string to displayed when recursion is
-	// detected within a Go value.
+	// DefaultRecursionMarker is the default string to displayed when recursion
+	// is detected within a Go value.
 	DefaultRecursionMarker = "<recursion>"
 )
 
 // Filter is a function that provides custom formatting logic for specific
 // values.
 //
-// It writes a formatted representation of v to w, and returns the number of
-// bytes written.
+// It optionally writes a formatted representation of v to w. If the filter does
+// not produce any output the default formatting logic is used.
 //
-// If the number of bytes written is non-zero, the default formatting logic is
-// skipped.
+// The f function can be used to render another value. This is useful when
+// producing filters that render collections of other values.
 //
 // Particular attention should be paid to the v.IsUnexported field. If this flag
 // is true, many operations on v.Value are unavailable.
-type Filter func(w io.Writer, v Value) (int, error)
+type Filter func(
+	w io.Writer,
+	v Value,
+	f func(w io.Writer, v Value) error,
+) error
 
 // Printer generates human-readable representations of Go values.
 //

--- a/time.go
+++ b/time.go
@@ -18,33 +18,37 @@ var (
 )
 
 // TimeFilter is a filter that formats time.Time values.
-func TimeFilter(w io.Writer, v Value) (n int, err error) {
+func TimeFilter(
+	w io.Writer,
+	v Value,
+	f func(w io.Writer, v Value) error,
+) (err error) {
 	defer must.Recover(&err)
 
 	if v.DynamicType == timeType {
-		mv, ok := unsafereflect.MakeMutable(v.Value)
-		if ok {
+		if mv, ok := unsafereflect.MakeMutable(v.Value); ok {
 			s := mv.Interface().(time.Time).Format(time.RFC3339Nano)
-			n += must.WriteString(w, s)
-			return
+			must.WriteString(w, s)
 		}
 	}
 
-	return 0, nil
+	return nil
 }
 
 // DurationFilter is a filter that formats time.Duration values.
-func DurationFilter(w io.Writer, v Value) (n int, err error) {
+func DurationFilter(
+	w io.Writer,
+	v Value,
+	f func(w io.Writer, v Value) error,
+) (err error) {
 	defer must.Recover(&err)
 
-	if v.DynamicType != durationType {
-		return 0, nil
+	if v.DynamicType == durationType {
+		if mv, ok := unsafereflect.MakeMutable(v.Value); ok {
+			s := mv.Interface().(time.Duration).String()
+			must.WriteString(w, s)
+		}
 	}
 
-	if mv, ok := unsafereflect.MakeMutable(v.Value); ok {
-		s := mv.Interface().(time.Duration).String()
-		n = must.WriteString(w, s)
-	}
-
-	return
+	return nil
 }

--- a/visitor.go
+++ b/visitor.go
@@ -45,10 +45,10 @@ func (vis *visitor) mustVisit(w io.Writer, v Value) {
 		if err := f(cw, v, vis.visit); err != nil {
 			panic(must.PanicSentinel{Cause: err})
 		}
-	}
 
-	if cw.Count() > 0 {
-		return
+		if cw.Count() > 0 {
+			return
+		}
 	}
 
 	switch v.DynamicType.Kind() {

--- a/visitor.go
+++ b/visitor.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/dogmatiq/iago/count"
 	"github.com/dogmatiq/iago/must"
 )
 
@@ -38,10 +39,16 @@ func (vis *visitor) mustVisit(w io.Writer, v Value) {
 	}
 	defer vis.leave(v)
 
+	cw := count.NewWriter(w)
+
 	for _, f := range vis.filters {
-		if n := must.Must(f(w, v)); n > 0 {
-			return
+		if err := f(cw, v, vis.visit); err != nil {
+			panic(must.PanicSentinel{Cause: err})
 		}
+	}
+
+	if cw.Count() > 0 {
+		return
 	}
 
 	switch v.DynamicType.Kind() {
@@ -80,6 +87,15 @@ func (vis *visitor) mustVisit(w io.Writer, v Value) {
 	}
 
 	return
+}
+
+// visit renders v to w.
+func (vis *visitor) visit(w io.Writer, v Value) (err error) {
+	defer must.Recover(&err)
+
+	vis.mustVisit(w, v)
+
+	return nil
 }
 
 // enter indicates that a potentially recursive value is about to be formatted.


### PR DESCRIPTION
This PR changes the signature of `dapper.Filter` function in two aspects:

1. a `format()` function was added as a third parameter of the `dapper.Filter` function to allow filter reverting to default formatting logic. The `format()` function can then be used in rendering container types in filters.

1. Instead of returning the number of bytes written to the given writer, `dapper.Filter` now returns boolean as a first return value. If a filter writes any output to the writer, this value is returned as true to signify that any further rendering logic should be skipped and that the filter overrode rendering.

This PR is the precursor to #18 and #26.