### PR TITLE
Make values mutable in visitor.mustVisit().

### DIFF
--- a/internal/unsafereflect/value.go
+++ b/internal/unsafereflect/value.go
@@ -12,22 +12,22 @@ import (
 // This allows invocation of methods on the value. Care must be taken not to
 // call methods that modify the returned value.
 //
-// It returns false if the value can not be made mutable.
-func MakeMutable(v reflect.Value) (reflect.Value, bool) {
+// It panics if the value can not be made mutable.
+func MakeMutable(v reflect.Value) reflect.Value {
 	if v.CanInterface() {
-		return v, true
+		return v
 	}
 
 	if flagsErr != nil {
 		// CODE COVERAGE: This branch is never executed unless the internals of
 		// the reflect package have changed in some incompatible way.
-		return v, false
+		panic(fmt.Sprintf("cannot make value %v mutable", v))
 	}
 
 	f := flags(&v)
 	*f &^= flagRO // clear the read-only flag
 
-	return v, true
+	return v
 }
 
 // flag is defined equivalently to the unexported reflect.flag type.

--- a/internal/unsafereflect/value.go
+++ b/internal/unsafereflect/value.go
@@ -21,7 +21,7 @@ func MakeMutable(v reflect.Value) reflect.Value {
 	if flagsErr != nil {
 		// CODE COVERAGE: This branch is never executed unless the internals of
 		// the reflect package have changed in some incompatible way.
-		panic(fmt.Sprintf("cannot make value %v mutable", v))
+		panic(fmt.Errorf("cannot make value %v mutable: %w", v, flagsErr))
 	}
 
 	f := flags(&v)

--- a/internal/unsafereflect/value_test.go
+++ b/internal/unsafereflect/value_test.go
@@ -13,12 +13,7 @@ func TestMakeMutable_exported_field(t *testing.T) {
 	rv := reflect.ValueOf(v)
 	rf := rv.FieldByName("F")
 
-	mv, ok := MakeMutable(rf)
-
-	if !ok {
-		t.Fatal("ok != true")
-	}
-
+	mv := MakeMutable(rf)
 	mv.Interface() // will panic if restrictions are not removed
 }
 
@@ -30,9 +25,8 @@ func TestMakeMutable_unexported_field(t *testing.T) {
 	rv := reflect.ValueOf(v)
 	rf := rv.FieldByName("f")
 
-	if mv, ok := MakeMutable(rf); ok {
-		mv.Interface() // will panic if restrictions are not removed
-	}
+	mv := MakeMutable(rf)
+	mv.Interface() // will panic if restrictions are not removed
 }
 
 // This test will fail if the internals of the reflect package have changed such

--- a/reflect.go
+++ b/reflect.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/dogmatiq/dapper/internal/unsafereflect"
 	"github.com/dogmatiq/iago/must"
 )
 
@@ -38,26 +37,17 @@ func ReflectTypeFilter(
 		must.WriteString(w, "reflect.Type(")
 	}
 
-	if mv, ok := unsafereflect.MakeMutable(v.Value); ok {
-		t := mv.Interface().(reflect.Type)
+	t := v.Value.Interface().(reflect.Type)
 
-		if s := t.PkgPath(); s != "" {
-			must.WriteString(w, s)
-			must.WriteByte(w, '.')
-		}
+	if s := t.PkgPath(); s != "" {
+		must.WriteString(w, s)
+		must.WriteByte(w, '.')
+	}
 
-		if s := t.Name(); s != "" {
-			must.WriteString(w, s)
-		} else {
-			must.WriteString(w, t.String())
-		}
+	if s := t.Name(); s != "" {
+		must.WriteString(w, s)
 	} else {
-		// CODE COVERAGE: This branch handles a failure within the unsafereflect
-		// package. Ideally this *should* never occur, but is included so as to
-		// avoid a panic on future Go versions. A test within the unsafereflect
-		// package will catch such a failure, at which point Dapper will need to
-		// be updated.
-		must.WriteString(w, "<unknown>")
+		must.WriteString(w, t.String())
 	}
 
 	// always render the pointer value for the type, this way when the field is

--- a/reflect.go
+++ b/reflect.go
@@ -50,12 +50,6 @@ func ReflectTypeFilter(
 		must.WriteString(w, t.String())
 	}
 
-	// always render the pointer value for the type, this way when the field is
-	// unexported we still get something we can compare to known types instead of a
-	// rendering of the reflect.rtype struct.
-	must.WriteByte(w, ' ')
-	must.WriteString(w, formatPointerHex(v.Value.Pointer(), false))
-
 	if ambiguous {
 		must.WriteByte(w, ')')
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,7 +1,6 @@
 package dapper_test
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -9,10 +8,6 @@ import (
 type reflectType struct {
 	Exported   reflect.Type
 	unexported reflect.Type
-}
-
-func formatReflectTypePointer(t reflect.Type) string {
-	return fmt.Sprintf("0x%x", reflect.ValueOf(t).Pointer())
 }
 
 func TestPrinter_ReflectTypeFilter(t *testing.T) {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -12,12 +12,9 @@ type reflectType struct {
 }
 
 var (
-	intType          = reflect.TypeOf(0)
-	intTypePointer   = formatReflectTypePointer(intType)
-	mapType          = reflect.TypeOf(map[string]string{})
-	mapTypePointer   = formatReflectTypePointer(mapType)
-	namedType        = reflect.TypeOf(named{})
-	namedTypePointer = formatReflectTypePointer(namedType)
+	intType   = reflect.TypeOf(0)
+	mapType   = reflect.TypeOf(map[string]string{})
+	namedType = reflect.TypeOf(named{})
 )
 
 func formatReflectTypePointer(t reflect.Type) string {
@@ -29,21 +26,21 @@ func TestPrinter_ReflectTypeFilter(t *testing.T) {
 		t,
 		"built-in type",
 		intType,
-		"reflect.Type(int "+intTypePointer+")",
+		"reflect.Type(int)",
 	)
 
 	test(
 		t,
 		"built-in parameterized type",
 		mapType,
-		"reflect.Type(map[string]string "+mapTypePointer+")",
+		"reflect.Type(map[string]string)",
 	)
 
 	test(
 		t,
 		"named type",
 		reflect.TypeOf(named{}),
-		"reflect.Type(github.com/dogmatiq/dapper_test.named "+namedTypePointer+")",
+		"reflect.Type(github.com/dogmatiq/dapper_test.named)",
 	)
 
 	typ := reflect.TypeOf(struct{ Int int }{})
@@ -51,7 +48,7 @@ func TestPrinter_ReflectTypeFilter(t *testing.T) {
 		t,
 		"anonymous struct",
 		typ,
-		"reflect.Type(struct { Int int } "+formatReflectTypePointer(typ)+")",
+		"reflect.Type(struct { Int int })",
 	)
 
 	typ = reflect.TypeOf((*interface{ Int() int })(nil)).Elem()
@@ -59,7 +56,7 @@ func TestPrinter_ReflectTypeFilter(t *testing.T) {
 		t,
 		"anonymous interface",
 		typ,
-		"reflect.Type(interface { Int() int } "+formatReflectTypePointer(typ)+")",
+		"reflect.Type(interface { Int() int })",
 	)
 
 	test(
@@ -71,7 +68,7 @@ func TestPrinter_ReflectTypeFilter(t *testing.T) {
 			reflect.TypeOf(0),
 		},
 		"{",
-		"    Type: reflect.Type(int "+intTypePointer+")",
+		"    Type: reflect.Type(int)",
 		"}",
 	)
 
@@ -83,8 +80,8 @@ func TestPrinter_ReflectTypeFilter(t *testing.T) {
 			unexported: reflect.TypeOf(0),
 		},
 		"dapper_test.reflectType{",
-		"    Exported:   int "+intTypePointer,
-		"    unexported: int "+intTypePointer,
+		"    Exported:   int",
+		"    unexported: int",
 		"}",
 	)
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -11,12 +11,6 @@ type reflectType struct {
 	unexported reflect.Type
 }
 
-var (
-	intType   = reflect.TypeOf(0)
-	mapType   = reflect.TypeOf(map[string]string{})
-	namedType = reflect.TypeOf(named{})
-)
-
 func formatReflectTypePointer(t reflect.Type) string {
 	return fmt.Sprintf("0x%x", reflect.ValueOf(t).Pointer())
 }
@@ -25,14 +19,14 @@ func TestPrinter_ReflectTypeFilter(t *testing.T) {
 	test(
 		t,
 		"built-in type",
-		intType,
+		reflect.TypeOf(0),
 		"reflect.Type(int)",
 	)
 
 	test(
 		t,
 		"built-in parameterized type",
-		mapType,
+		reflect.TypeOf(map[string]string{}),
 		"reflect.Type(map[string]string)",
 	)
 

--- a/time.go
+++ b/time.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/dogmatiq/dapper/internal/unsafereflect"
 	"github.com/dogmatiq/iago/must"
 )
 
@@ -26,10 +25,9 @@ func TimeFilter(
 	defer must.Recover(&err)
 
 	if v.DynamicType == timeType {
-		if mv, ok := unsafereflect.MakeMutable(v.Value); ok {
-			s := mv.Interface().(time.Time).Format(time.RFC3339Nano)
-			must.WriteString(w, s)
-		}
+		s := v.Value.Interface().(time.Time).Format(time.RFC3339Nano)
+		must.WriteString(w, s)
+
 	}
 
 	return nil
@@ -44,10 +42,8 @@ func DurationFilter(
 	defer must.Recover(&err)
 
 	if v.DynamicType == durationType {
-		if mv, ok := unsafereflect.MakeMutable(v.Value); ok {
-			s := mv.Interface().(time.Duration).String()
-			must.WriteString(w, s)
-		}
+		s := v.Value.Interface().(time.Duration).String()
+		must.WriteString(w, s)
 	}
 
 	return nil

--- a/time.go
+++ b/time.go
@@ -27,7 +27,6 @@ func TimeFilter(
 	if v.DynamicType == timeType {
 		s := v.Value.Interface().(time.Time).Format(time.RFC3339Nano)
 		must.WriteString(w, s)
-
 	}
 
 	return nil

--- a/visitor.go
+++ b/visitor.go
@@ -40,55 +40,53 @@ func (vis *visitor) mustVisit(w io.Writer, v Value) {
 	}
 	defer vis.leave(v)
 
-	var ok bool
-	if v.Value, ok = unsafereflect.MakeMutable(v.Value); ok {
+	v.Value = unsafereflect.MakeMutable(v.Value)
 
-		cw := count.NewWriter(w)
+	cw := count.NewWriter(w)
 
-		for _, f := range vis.filters {
-			if err := f(cw, v, vis.visit); err != nil {
-				panic(must.PanicSentinel{Cause: err})
-			}
-
-			if cw.Count() > 0 {
-				return
-			}
+	for _, f := range vis.filters {
+		if err := f(cw, v, vis.visit); err != nil {
+			panic(must.PanicSentinel{Cause: err})
 		}
 
-		switch v.DynamicType.Kind() {
-		case reflect.String:
-			vis.visitString(w, v)
-		case reflect.Bool:
-			vis.visitBool(w, v)
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			vis.visitInt(w, v)
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			vis.visitUint(w, v)
-		case reflect.Float32, reflect.Float64:
-			vis.visitFloat(w, v)
-		case reflect.Complex64, reflect.Complex128:
-			vis.visitComplex(w, v)
-		case reflect.Uintptr:
-			vis.visitUintptr(w, v)
-		case reflect.UnsafePointer:
-			vis.visitUnsafePointer(w, v)
-		case reflect.Chan:
-			vis.visitChan(w, v)
-		case reflect.Func:
-			vis.visitFunc(w, v)
-		case reflect.Interface:
-			vis.visitInterface(w, v)
-		case reflect.Map:
-			vis.visitMap(w, v)
-		case reflect.Ptr:
-			vis.visitPtr(w, v)
-		case reflect.Array:
-			vis.visitArray(w, v)
-		case reflect.Slice:
-			vis.visitSlice(w, v)
-		case reflect.Struct:
-			vis.visitStruct(w, v)
+		if cw.Count() > 0 {
+			return
 		}
+	}
+
+	switch v.DynamicType.Kind() {
+	case reflect.String:
+		vis.visitString(w, v)
+	case reflect.Bool:
+		vis.visitBool(w, v)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		vis.visitInt(w, v)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		vis.visitUint(w, v)
+	case reflect.Float32, reflect.Float64:
+		vis.visitFloat(w, v)
+	case reflect.Complex64, reflect.Complex128:
+		vis.visitComplex(w, v)
+	case reflect.Uintptr:
+		vis.visitUintptr(w, v)
+	case reflect.UnsafePointer:
+		vis.visitUnsafePointer(w, v)
+	case reflect.Chan:
+		vis.visitChan(w, v)
+	case reflect.Func:
+		vis.visitFunc(w, v)
+	case reflect.Interface:
+		vis.visitInterface(w, v)
+	case reflect.Map:
+		vis.visitMap(w, v)
+	case reflect.Ptr:
+		vis.visitPtr(w, v)
+	case reflect.Array:
+		vis.visitArray(w, v)
+	case reflect.Slice:
+		vis.visitSlice(w, v)
+	case reflect.Struct:
+		vis.visitStruct(w, v)
 	}
 	return
 }

--- a/visitor.go
+++ b/visitor.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/dogmatiq/dapper/internal/unsafereflect"
 	"github.com/dogmatiq/iago/count"
 	"github.com/dogmatiq/iago/must"
 )
@@ -39,53 +40,56 @@ func (vis *visitor) mustVisit(w io.Writer, v Value) {
 	}
 	defer vis.leave(v)
 
-	cw := count.NewWriter(w)
+	var ok bool
+	if v.Value, ok = unsafereflect.MakeMutable(v.Value); ok {
 
-	for _, f := range vis.filters {
-		if err := f(cw, v, vis.visit); err != nil {
-			panic(must.PanicSentinel{Cause: err})
+		cw := count.NewWriter(w)
+
+		for _, f := range vis.filters {
+			if err := f(cw, v, vis.visit); err != nil {
+				panic(must.PanicSentinel{Cause: err})
+			}
+
+			if cw.Count() > 0 {
+				return
+			}
 		}
 
-		if cw.Count() > 0 {
-			return
+		switch v.DynamicType.Kind() {
+		case reflect.String:
+			vis.visitString(w, v)
+		case reflect.Bool:
+			vis.visitBool(w, v)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			vis.visitInt(w, v)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			vis.visitUint(w, v)
+		case reflect.Float32, reflect.Float64:
+			vis.visitFloat(w, v)
+		case reflect.Complex64, reflect.Complex128:
+			vis.visitComplex(w, v)
+		case reflect.Uintptr:
+			vis.visitUintptr(w, v)
+		case reflect.UnsafePointer:
+			vis.visitUnsafePointer(w, v)
+		case reflect.Chan:
+			vis.visitChan(w, v)
+		case reflect.Func:
+			vis.visitFunc(w, v)
+		case reflect.Interface:
+			vis.visitInterface(w, v)
+		case reflect.Map:
+			vis.visitMap(w, v)
+		case reflect.Ptr:
+			vis.visitPtr(w, v)
+		case reflect.Array:
+			vis.visitArray(w, v)
+		case reflect.Slice:
+			vis.visitSlice(w, v)
+		case reflect.Struct:
+			vis.visitStruct(w, v)
 		}
 	}
-
-	switch v.DynamicType.Kind() {
-	case reflect.String:
-		vis.visitString(w, v)
-	case reflect.Bool:
-		vis.visitBool(w, v)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		vis.visitInt(w, v)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		vis.visitUint(w, v)
-	case reflect.Float32, reflect.Float64:
-		vis.visitFloat(w, v)
-	case reflect.Complex64, reflect.Complex128:
-		vis.visitComplex(w, v)
-	case reflect.Uintptr:
-		vis.visitUintptr(w, v)
-	case reflect.UnsafePointer:
-		vis.visitUnsafePointer(w, v)
-	case reflect.Chan:
-		vis.visitChan(w, v)
-	case reflect.Func:
-		vis.visitFunc(w, v)
-	case reflect.Interface:
-		vis.visitInterface(w, v)
-	case reflect.Map:
-		vis.visitMap(w, v)
-	case reflect.Ptr:
-		vis.visitPtr(w, v)
-	case reflect.Array:
-		vis.visitArray(w, v)
-	case reflect.Slice:
-		vis.visitSlice(w, v)
-	case reflect.Struct:
-		vis.visitStruct(w, v)
-	}
-
 	return
 }
 


### PR DESCRIPTION
This commit converts the value to mutable in visitor.mustVisit() values for all switch cases. This change is required to allow fully functional user-defined filters added to the library.

Consequently, the value conversions to mutable state were removed from library-defined filters (`dapper.ReflectTypeFilter`, `dapper.TimeFilter`, and `dapper.DurationFilter`).