### PR TITLE
Move printer configuration into its own data type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Add `Config` to enscapsulate the configuration of a `Printer`
 
+## Changed
+
+- **[BC]** Change `DefaultIndent` from `string` constant to `[]byte`
+
 ## Removed
 
 - **[BC]** Remove `Printer.Filters`, `Indent` and `RecursionMarker`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+## Added
+
+- Add `Config` to enscapsulate the configuration of a `Printer`
+
+## Removed
+
+- **[BC]** Remove `Printer.Filters`, `Indent` and `RecursionMarker`
+- **[BC]** Pass the printer config to `Filter` functions
+
 ## [0.3.5] - 2019-11-06
 
 ## Changed

--- a/array.go
+++ b/array.go
@@ -23,7 +23,7 @@ func (vis *visitor) visitArray(w io.Writer, v Value) {
 		return
 	}
 
-	i := indent.NewIndenter(w, []byte(vis.config.Indent))
+	i := indent.NewIndenter(w, vis.config.Indent)
 
 	must.WriteString(w, "{\n")
 	if v.DynamicType.Elem() == byteType {

--- a/array.go
+++ b/array.go
@@ -23,7 +23,7 @@ func (vis *visitor) visitArray(w io.Writer, v Value) {
 		return
 	}
 
-	i := indent.NewIndenter(w, vis.indent)
+	i := indent.NewIndenter(w, []byte(vis.config.Indent))
 
 	must.WriteString(w, "{\n")
 	if v.DynamicType.Elem() == byteType {

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,23 @@
+package dapper
+
+import "io"
+
+// Filter is a function that provides custom formatting logic for specific
+// values.
+//
+// It optionally writes a formatted representation of v to w. If the filter does
+// not produce any output the default formatting logic is used.
+//
+// c is the configuration used by the Printer that is invoking the filter.
+//
+// The f function can be used to render another value. This is useful when
+// producing filters that render collections of other values.
+//
+// Particular attention should be paid to the v.IsUnexported field. If this flag
+// is true, many operations on v.Value are unavailable.
+type Filter func(
+	w io.Writer,
+	v Value,
+	c Config,
+	f func(w io.Writer, v Value) error,
+) error

--- a/filter_test.go
+++ b/filter_test.go
@@ -69,7 +69,7 @@ func TestPrinter_Filter(t *testing.T) {
 
 	t.Run("is passed the printer's config", func(t *testing.T) {
 		cfg := Config{
-			Indent:          "--->",
+			Indent:          []byte("--->"),
 			RecursionMarker: "*LOOP*",
 		}
 

--- a/map.go
+++ b/map.go
@@ -29,7 +29,7 @@ func (vis *visitor) visitMap(w io.Writer, v Value) {
 	}
 
 	must.WriteString(w, "{\n")
-	vis.visitMapElements(indent.NewIndenter(w, vis.indent), v)
+	vis.visitMapElements(indent.NewIndenter(w, []byte(vis.config.Indent)), v)
 	must.WriteByte(w, '}')
 }
 

--- a/map.go
+++ b/map.go
@@ -29,7 +29,7 @@ func (vis *visitor) visitMap(w io.Writer, v Value) {
 	}
 
 	must.WriteString(w, "{\n")
-	vis.visitMapElements(indent.NewIndenter(w, []byte(vis.config.Indent)), v)
+	vis.visitMapElements(indent.NewIndenter(w, vis.config.Indent), v)
 	must.WriteByte(w, '}')
 }
 

--- a/printer.go
+++ b/printer.go
@@ -10,14 +10,12 @@ import (
 	"github.com/dogmatiq/iago/must"
 )
 
-const (
-	// DefaultIndent is the default indent string used to indent nested values.
-	DefaultIndent = "    "
+// DefaultIndent is the default indent string used to indent nested values.
+var DefaultIndent = []byte("    ")
 
-	// DefaultRecursionMarker is the default string to displayed when recursion
-	// is detected within a Go value.
-	DefaultRecursionMarker = "<recursion>"
-)
+// DefaultRecursionMarker is the default string to displayed when recursion
+// is detected within a Go value.
+const DefaultRecursionMarker = "<recursion>"
 
 // Config holds the configuration for a printer.
 type Config struct {
@@ -26,7 +24,7 @@ type Config struct {
 
 	// Indent is the string used to indent nested values.
 	// If it is empty, DefaultIndent is used.
-	Indent string
+	Indent []byte
 
 	// RecursionMarker is a string that is displayed instead of a value's
 	// representation when recursion has been detected.
@@ -57,7 +55,7 @@ func (p *Printer) Write(w io.Writer, v interface{}) (n int, err error) {
 		config: p.Config,
 	}
 
-	if vis.config.Indent == "" {
+	if len(vis.config.Indent) == 0 {
 		vis.config.Indent = DefaultIndent
 	}
 

--- a/printer.go
+++ b/printer.go
@@ -13,7 +13,7 @@ import (
 // DefaultIndent is the default indent string used to indent nested values.
 var DefaultIndent = []byte("    ")
 
-// DefaultRecursionMarker is the default string to displayed when recursion
+// DefaultRecursionMarker is the default string to display when recursion
 // is detected within a Go value.
 const DefaultRecursionMarker = "<recursion>"
 

--- a/reflect.go
+++ b/reflect.go
@@ -14,6 +14,7 @@ var reflectTypeType = reflect.TypeOf((*reflect.Type)(nil)).Elem()
 func ReflectTypeFilter(
 	w io.Writer,
 	v Value,
+	_ Config,
 	f func(w io.Writer, v Value) error,
 ) (err error) {
 	defer must.Recover(&err)

--- a/struct.go
+++ b/struct.go
@@ -24,7 +24,7 @@ func (vis *visitor) visitStruct(w io.Writer, v Value) {
 	}
 
 	must.WriteString(w, "{\n")
-	vis.visitStructFields(indent.NewIndenter(w, []byte(vis.config.Indent)), v)
+	vis.visitStructFields(indent.NewIndenter(w, vis.config.Indent), v)
 	must.WriteByte(w, '}')
 }
 

--- a/struct.go
+++ b/struct.go
@@ -24,7 +24,7 @@ func (vis *visitor) visitStruct(w io.Writer, v Value) {
 	}
 
 	must.WriteString(w, "{\n")
-	vis.visitStructFields(indent.NewIndenter(w, vis.indent), v)
+	vis.visitStructFields(indent.NewIndenter(w, []byte(vis.config.Indent)), v)
 	must.WriteByte(w, '}')
 }
 

--- a/sync.go
+++ b/sync.go
@@ -23,6 +23,7 @@ var (
 func SyncFilter(
 	w io.Writer,
 	v Value,
+	_ Config,
 	f func(w io.Writer, v Value) error,
 ) error {
 	switch v.DynamicType {

--- a/time.go
+++ b/time.go
@@ -20,6 +20,7 @@ var (
 func TimeFilter(
 	w io.Writer,
 	v Value,
+	_ Config,
 	f func(w io.Writer, v Value) error,
 ) (err error) {
 	defer must.Recover(&err)
@@ -36,6 +37,7 @@ func TimeFilter(
 func DurationFilter(
 	w io.Writer,
 	v Value,
+	_ Config,
 	f func(w io.Writer, v Value) error,
 ) (err error) {
 	defer must.Recover(&err)

--- a/visitor.go
+++ b/visitor.go
@@ -12,14 +12,8 @@ import (
 
 // visitor walks a Go value in order to render it.
 type visitor struct {
-	// filters is the set of filters to apply.
-	filters []Filter
-
-	// indent is the string used to indent nested values.
-	indent []byte
-
-	// recursionMarker is the string used to represent recursion within a value.
-	recursionMarker string
+	// config is the printer's configuration.
+	config Config
 
 	// recursionSet is the set of potentially recursive values that are currently
 	// being visited.
@@ -44,8 +38,8 @@ func (vis *visitor) mustVisit(w io.Writer, v Value) {
 
 	cw := count.NewWriter(w)
 
-	for _, f := range vis.filters {
-		if err := f(cw, v, vis.visit); err != nil {
+	for _, f := range vis.config.Filters {
+		if err := f(cw, v, vis.config, vis.visit); err != nil {
 			panic(must.PanicSentinel{Cause: err})
 		}
 
@@ -112,10 +106,10 @@ func (vis *visitor) enter(w io.Writer, v Value) bool {
 			if v.IsAmbiguousType() {
 				must.WriteString(w, v.TypeName())
 				must.WriteByte(w, '(')
-				must.WriteString(w, vis.recursionMarker)
+				must.WriteString(w, vis.config.RecursionMarker)
 				must.WriteByte(w, ')')
 			} else {
-				must.WriteString(w, vis.recursionMarker)
+				must.WriteString(w, vis.config.RecursionMarker)
 			}
 
 			return true


### PR DESCRIPTION
This commit adds the `Config` type to encapsulate the configurable properties of a `Printer`.

This further allows us to pass this configuration on to the `Filter` functions, so that they can format in accordance with the configuration. For example, using the correct indentation prefix.