### PR TITLE
Collapse zero-value structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - **[BC]** Change `DefaultIndent` from `string` constant to `[]byte`
 - **[BC]** The `Filter` function signature now accepts a `Config` and `FilterPrinter`
+- Zero-value structs are now collapsed to `StructName{<zero>}`
 
 ## Removed
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -70,6 +70,7 @@ func TestPrinter_Filter(t *testing.T) {
 	t.Run("is passed the printer's config", func(t *testing.T) {
 		cfg := Config{
 			Indent:          []byte("--->"),
+			ZeroValueMarker: "*ZERO*",
 			RecursionMarker: "*LOOP*",
 		}
 

--- a/interface_test.go
+++ b/interface_test.go
@@ -4,6 +4,7 @@ import "testing"
 
 type interfaces struct {
 	Iface interface{}
+	Force bool // prevent rendering of the zero-value marker
 }
 
 type iface interface{}
@@ -17,18 +18,20 @@ func TestPrinter_Interface(t *testing.T) {
 	test(
 		t,
 		"nil interface in named struct",
-		interfaces{},
+		interfaces{Force: true},
 		"github.com/dogmatiq/dapper_test.interfaces{",
 		"    Iface: nil",
+		"    Force: true",
 		"}",
 	)
 
 	test(
 		t,
 		"non-nil interface in named struct",
-		interfaces{int(100)},
+		interfaces{Iface: int(100)},
 		"github.com/dogmatiq/dapper_test.interfaces{",
 		"    Iface: int(100)",
+		"    Force: false",
 		"}",
 	)
 

--- a/map_test.go
+++ b/map_test.go
@@ -10,6 +10,7 @@ type maps struct {
 	Ints        map[int]int
 	IfaceKeys   map[interface{}]int
 	IfaceValues map[int]interface{}
+	Force       bool // prevent rendering of the zero-value marker
 }
 
 // This test verifies that that map key/value types are not rendered when they can
@@ -33,16 +34,16 @@ func TestPrinter_Map(t *testing.T) {
 // This test verifies the formatting of map key/values when the type
 // information omitted because it can be inferred from the context in which the
 // values are rendered.
-
 func TestPrinter_MapInNamedStruct(t *testing.T) {
 	test(
 		t,
 		"nil maps",
-		maps{},
+		maps{Force: true},
 		"github.com/dogmatiq/dapper_test.maps{",
 		"    Ints:        nil",
 		"    IfaceKeys:   nil",
 		"    IfaceValues: nil",
+		"    Force:       true",
 		"}",
 	)
 
@@ -58,6 +59,7 @@ func TestPrinter_MapInNamedStruct(t *testing.T) {
 		"    Ints:        {}",
 		"    IfaceKeys:   {}",
 		"    IfaceValues: {}",
+		"    Force:       false",
 		"}",
 	)
 
@@ -82,6 +84,7 @@ func TestPrinter_MapInNamedStruct(t *testing.T) {
 		"        5: int(500)",
 		"        6: int(600)",
 		"    }",
+		"    Force:       false",
 		"}",
 	)
 }

--- a/printer.go
+++ b/printer.go
@@ -13,9 +13,15 @@ import (
 // DefaultIndent is the default indent string used to indent nested values.
 var DefaultIndent = []byte("    ")
 
-// DefaultRecursionMarker is the default string to display when recursion
-// is detected within a Go value.
-const DefaultRecursionMarker = "<recursion>"
+const (
+	// DefaultZeroValueMarker is the default string to display when rendering a
+	// zero-value struct.
+	DefaultZeroValueMarker = "<zero>"
+
+	// DefaultRecursionMarker is the default string to display when recursion
+	// is detected within a Go value.
+	DefaultRecursionMarker = "<recursion>"
+)
 
 // Config holds the configuration for a printer.
 type Config struct {
@@ -25,6 +31,11 @@ type Config struct {
 	// Indent is the string used to indent nested values.
 	// If it is empty, DefaultIndent is used.
 	Indent []byte
+
+	// ZeroValueMarker is a string that is displayed instead of a structs field
+	// list when it is the zero-value. If it is empty, DefaultZeroValueMarker is
+	// used.
+	ZeroValueMarker string
 
 	// RecursionMarker is a string that is displayed instead of a value's
 	// representation when recursion has been detected.
@@ -61,6 +72,10 @@ func (p *Printer) Write(w io.Writer, v interface{}) (n int, err error) {
 
 	if len(vis.config.Indent) == 0 {
 		vis.config.Indent = DefaultIndent
+	}
+
+	if vis.config.ZeroValueMarker == "" {
+		vis.config.ZeroValueMarker = DefaultZeroValueMarker
 	}
 
 	if vis.config.RecursionMarker == "" {

--- a/slice_test.go
+++ b/slice_test.go
@@ -5,6 +5,7 @@ import "testing"
 type slices struct {
 	Ints   []int
 	Ifaces []interface{}
+	Force  bool // prevent rendering of the zero-value marker
 }
 
 // This test verifies that that slice value types are not rendered when they can
@@ -50,10 +51,11 @@ func TestPrinter_SliceInNamedStruct(t *testing.T) {
 	test(
 		t,
 		"nil slices",
-		slices{},
+		slices{Force: true},
 		"github.com/dogmatiq/dapper_test.slices{",
 		"    Ints:   nil",
 		"    Ifaces: nil",
+		"    Force:  true",
 		"}",
 	)
 
@@ -67,6 +69,7 @@ func TestPrinter_SliceInNamedStruct(t *testing.T) {
 		"github.com/dogmatiq/dapper_test.slices{",
 		"    Ints:   {}",
 		"    Ifaces: {}",
+		"    Force:  false",
 		"}",
 	)
 
@@ -88,6 +91,7 @@ func TestPrinter_SliceInNamedStruct(t *testing.T) {
 		"        int(500)",
 		"        int(600)",
 		"    }",
+		"    Force:  false",
 		"}",
 	)
 }

--- a/struct.go
+++ b/struct.go
@@ -23,6 +23,13 @@ func (vis *visitor) visitStruct(w io.Writer, v Value) {
 		return
 	}
 
+	if v.Value.IsZero() && !v.IsAnonymousType() {
+		must.WriteByte(w, '{')
+		must.WriteString(w, vis.config.ZeroValueMarker)
+		must.WriteByte(w, '}')
+		return
+	}
+
 	must.WriteString(w, "{\n")
 	vis.visitStructFields(indent.NewIndenter(w, vis.config.Indent), v)
 	must.WriteByte(w, '}')

--- a/struct_test.go
+++ b/struct_test.go
@@ -174,3 +174,27 @@ func TestPrinter_StructUnexportedFields(t *testing.T) {
 		"}",
 	)
 }
+
+// This test verifies that zero-value structs are rendered without all of their
+// nested fields only if they are not anonymous.
+func TestPrinter_ZeroValueStruct(t *testing.T) {
+	test(
+		t,
+		"no fields are rendered for named zero-value structs",
+		named{},
+		"github.com/dogmatiq/dapper_test.named{<zero>}",
+	)
+
+	test(
+		t,
+		"fields are always rendered for anonymous zero-value structs",
+		struct {
+			Int   int
+			Iface interface{}
+		}{},
+		"{",
+		"    Int:   int(0)",
+		"    Iface: interface{}(nil)",
+		"}",
+	)
+}

--- a/sync_test.go
+++ b/sync_test.go
@@ -114,18 +114,21 @@ func TestPrinter_SyncFilter(t *testing.T) {
 	)
 
 	type syncTypes struct {
-		w    sync.Mutex
-		rw   sync.RWMutex
-		once sync.Once
+		w     sync.Mutex
+		rw    sync.RWMutex
+		once  sync.Once
+		force bool // prevent rendering of the zero-value marker
 	}
+
 	test(
 		t,
 		"excludes type information if it is not ambiguous",
-		syncTypes{},
+		syncTypes{force: true},
 		"github.com/dogmatiq/dapper_test.syncTypes{",
-		"    w:    <unlocked>",
-		"    rw:   <unlocked>",
-		"    once: <pending>",
+		"    w:     <unlocked>",
+		"    rw:    <unlocked>",
+		"    once:  <pending>",
+		"    force: true",
 		"}",
 	)
 


### PR DESCRIPTION
Fixes #5 

This PR changes the printer behaviour to render zero-value struct types more concisely when all of its fields are zero-values.

Empty structs, that is, structs with no fields are not affected by this change, as doing so would actually increase the output size and lose information.

The zero value "marker" is configurable, much the same as the recusion marker.

Note: Several of the existing tests that use their own test structs had to be modified to include a "force" boolean in order to prevent the printer from using this new logic when we're actually testing the rendering of zero-values of other types.