### PR TITLE
Drop the `error` return value from `FilterPrinter.Write()`.

### DIFF
--- a/array.go
+++ b/array.go
@@ -47,7 +47,7 @@ func (vis *visitor) visitArrayValues(w io.Writer, v Value) {
 			elem = elem.Elem()
 		}
 
-		vis.mustVisit(
+		vis.Write(
 			w,
 			Value{
 				Value:                  elem,

--- a/filter.go
+++ b/filter.go
@@ -26,7 +26,7 @@ type Filter func(
 type FilterPrinter interface {
 	// Write writes a pretty-printed representation of v to w using the default
 	// printer settings.
-	Write(w io.Writer, v Value) error
+	Write(w io.Writer, v Value)
 
 	// FormatTypeName returns the name of v's dynamic type, rendered as per the
 	// printer's configuration.

--- a/filter_test.go
+++ b/filter_test.go
@@ -33,7 +33,7 @@ func TestPrinter_Filter(t *testing.T) {
 
 				fv := v.Value.FieldByName("i")
 
-				if err := p.Write(
+				p.Write(
 					w,
 					Value{
 						Value:                  fv,
@@ -43,12 +43,11 @@ func TestPrinter_Filter(t *testing.T) {
 						IsAmbiguousStaticType:  false,
 						IsUnexported:           true,
 					},
-				); err != nil {
-					return err
-				}
+				)
 
 				must.WriteByte(w, '>')
 			}
+
 			return nil
 		}
 

--- a/map.go
+++ b/map.go
@@ -55,7 +55,7 @@ func (vis *visitor) visitMapElements(w io.Writer, v Value) {
 			must.WriteString(w, strings.Repeat(" ", alignment-mk.Width))
 		}
 
-		vis.mustVisit(
+		vis.Write(
 			w,
 			Value{
 				Value:                  mv,
@@ -95,7 +95,7 @@ func (vis *visitor) formatMapKeys(v Value) (keys []mapKey, alignment int) {
 			mk = mk.Elem()
 		}
 
-		vis.mustVisit(
+		vis.Write(
 			&w,
 			Value{
 				Value:                  mk,

--- a/printer.go
+++ b/printer.go
@@ -91,7 +91,7 @@ func (p *Printer) Write(w io.Writer, v interface{}) (n int, err error) {
 
 	cw := count.NewWriter(w)
 
-	vis.mustVisit(
+	vis.Write(
 		cw,
 		Value{
 			Value:                  rv,

--- a/ptr.go
+++ b/ptr.go
@@ -19,7 +19,7 @@ func (vis *visitor) visitPtr(w io.Writer, v Value) {
 
 	elem := v.Value.Elem()
 
-	vis.mustVisit(
+	vis.Write(
 		w,
 		Value{
 			Value:                  elem,

--- a/reflect.go
+++ b/reflect.go
@@ -16,9 +16,7 @@ func ReflectTypeFilter(
 	v Value,
 	_ Config,
 	p FilterPrinter,
-) (err error) {
-	defer must.Recover(&err)
-
+) error {
 	if !v.DynamicType.Implements(reflectTypeType) {
 		return nil
 	}

--- a/struct.go
+++ b/struct.go
@@ -53,7 +53,7 @@ func (vis *visitor) visitStructFields(w io.Writer, v Value) {
 		must.WriteString(w, f.Name)
 		must.WriteString(w, ": ")
 		must.WriteString(w, strings.Repeat(" ", alignment-len(f.Name)))
-		vis.mustVisit(
+		vis.Write(
 			w,
 			Value{
 				Value:                  fv,

--- a/sync.go
+++ b/sync.go
@@ -42,9 +42,7 @@ func mutexFilter(
 	w io.Writer,
 	v Value,
 	p FilterPrinter,
-) (err error) {
-	defer must.Recover(&err)
-
+) error {
 	state := v.Value.FieldByName("state")
 
 	s := "<unknown state>"
@@ -63,16 +61,14 @@ func mutexFilter(
 		must.Fprintf(w, "%v", s)
 	}
 
-	return err
+	return nil
 }
 
 func rwMutexFilter(
 	w io.Writer,
 	v Value,
 	p FilterPrinter,
-) (err error) {
-	defer must.Recover(&err)
-
+) error {
 	wait := v.Value.FieldByName("readerWait")
 	count := v.Value.FieldByName("readerCount")
 	write := v.Value.FieldByName("w")
@@ -100,16 +96,14 @@ func rwMutexFilter(
 		must.Fprintf(w, "%v", s)
 	}
 
-	return err
+	return nil
 }
 
 func onceFilter(
 	w io.Writer,
 	v Value,
 	p FilterPrinter,
-) (err error) {
-	defer must.Recover(&err)
-
+) error {
 	done := v.Value.FieldByName("done")
 
 	s := "<unknown state>"
@@ -128,7 +122,7 @@ func onceFilter(
 		must.Fprintf(w, "%v", s)
 	}
 
-	return err
+	return nil
 }
 
 // isInt returns true if v is one of the signed integer types.

--- a/time.go
+++ b/time.go
@@ -22,9 +22,7 @@ func TimeFilter(
 	v Value,
 	_ Config,
 	p FilterPrinter,
-) (err error) {
-	defer must.Recover(&err)
-
+) error {
 	if v.DynamicType == timeType {
 		s := v.Value.Interface().(time.Time).Format(time.RFC3339Nano)
 		must.WriteString(w, s)
@@ -39,9 +37,7 @@ func DurationFilter(
 	v Value,
 	_ Config,
 	p FilterPrinter,
-) (err error) {
-	defer must.Recover(&err)
-
+) error {
 	if v.DynamicType == durationType {
 		s := v.Value.Interface().(time.Duration).String()
 		must.WriteString(w, s)

--- a/visitor.go
+++ b/visitor.go
@@ -24,10 +24,10 @@ type visitor struct {
 	recursionSet map[uintptr]struct{}
 }
 
-// mustVisit renders v to w.
+// Write renders v to w.
 //
 // It panics if an error occurs writing to w.
-func (vis *visitor) mustVisit(w io.Writer, v Value) {
+func (vis *visitor) Write(w io.Writer, v Value) {
 	if v.Value.Kind() == reflect.Invalid {
 		must.WriteString(w, "interface{}(nil)")
 		return
@@ -87,15 +87,6 @@ func (vis *visitor) mustVisit(w io.Writer, v Value) {
 		vis.visitStruct(w, v)
 	}
 	return
-}
-
-// Write renders v to w.
-func (vis *visitor) Write(w io.Writer, v Value) (err error) {
-	defer must.Recover(&err)
-
-	vis.mustVisit(w, v)
-
-	return nil
 }
 
 // FormatTypeName returns the name of v's dynamic type, rendered as per the


### PR DESCRIPTION
This PR removes the `error` return value from the `FilterPrinter.Write()` function, as the only way it can fail is with one of the `must.PanicSentinel` values from the Iago IO helper library. Such panic values are already caught by the printer that invokes the filter.

This means that the filter implementers no longer need to check for and propagate this error.

Filter implementers may still return an error OR panic using Iago to signal a failure.