### PR TITLE
Refactor to share map printing logic.

### DIFF
--- a/map.go
+++ b/map.go
@@ -11,130 +11,150 @@ import (
 )
 
 // visitMap formats values with a kind of reflect.Map.
-//
-// TODO(jmalloc): sort numerically-keyed maps numerically
 func (vis *visitor) visitMap(w io.Writer, v Value) {
 	if v.Value.IsNil() {
 		vis.renderNil(w, v)
 		return
 	}
 
-	if v.IsAmbiguousType() {
-		must.WriteString(w, vis.FormatTypeName(v))
-	}
-
-	if v.Value.Len() == 0 {
-		must.WriteString(w, "{}")
-		return
-	}
-
 	r := mapRenderer{
-		p: vis,
+		Map:       v,
+		KeyType:   v.DynamicType.Key(),
+		ValueType: v.DynamicType.Elem(),
+		Printer:   vis,
+		Indent:    vis.config.Indent,
 	}
 
 	for _, mk := range v.Value.MapKeys() {
 		mv := v.Value.MapIndex(mk)
-		r.add(
-			buildValue(mk, v.DynamicType.Key(), v.IsUnexported),
-			buildValue(mv, v.DynamicType.Elem(), v.IsUnexported),
-		)
+		r.Add(mk, mv)
 	}
 
-	sort.Slice(
-		r.items,
-		func(i, j int) bool {
-			return r.items[i].keyString < r.items[j].keyString
-		},
-	)
-
-	// compensate for the ":" added to the last line"
-	if !r.alignToLastLine {
-		r.alignment--
-	}
-
-	must.WriteString(w, "{\n")
-	r.print(indent.NewIndenter(w, vis.config.Indent))
-	must.WriteByte(w, '}')
+	r.Print(w)
 }
 
-func buildValue(
-	v reflect.Value,
-	staticType reflect.Type,
-	unexported bool,
-) Value {
-	isInterface := staticType.Kind() == reflect.Interface
-	// unwrap interface values so that elem has it's actual type/kind, and not
-	// that of reflect.Interface.
-	if isInterface && !v.IsNil() {
-		v = v.Elem()
-	}
+// mapPrinter is used to render the keys and values of a map.
+type mapPrinter = FilterPrinter
 
-	return Value{
-		Value:                  v,
-		DynamicType:            v.Type(),
-		StaticType:             staticType,
-		IsAmbiguousDynamicType: isInterface,
-		IsAmbiguousStaticType:  false,
-		IsUnexported:           unexported,
-	}
+// mapPair is a pre-rendered key/value pair from a map.
+type mapPair struct {
+	KeyWidth int
+	Key      string
+	Value    string
 }
 
-type mapItem struct {
-	keyWidth    int
-	keyString   string
-	valueString string
+// Write renders the key/value pair to w.
+func (p *mapPair) Write(w io.Writer, alignment int) {
+	must.WriteString(w, p.Key)
+	must.WriteString(w, ": ")
+
+	// align values only if the key fits in a single line
+	if !strings.ContainsRune(p.Key, '\n') {
+		must.WriteString(w, strings.Repeat(" ", alignment-p.KeyWidth))
+	}
+
+	must.WriteString(w, p.Value)
+	must.WriteString(w, "\n")
 }
 
+// mapRenderer encapsulates the logic used to render map-like containers.
 type mapRenderer struct {
-	p               FilterPrinter
-	items           []mapItem
+	Map       Value
+	KeyType   reflect.Type
+	ValueType reflect.Type
+	Printer   mapPrinter
+	Indent    []byte
+
+	pairs           []mapPair
 	alignment       int
 	alignToLastLine bool
 }
 
-func (r *mapRenderer) add(key, val Value) bool {
-	var sb strings.Builder
-
-	r.p.Write(&sb, key)
-
-	ks := sb.String()
+// Add adds a key/value pair to the renderer.
+func (r *mapRenderer) Add(k, v reflect.Value) {
+	ks := r.format(k, r.KeyType)
+	vs := r.format(v, r.ValueType)
 
 	max, last := widths(ks)
 	if max > r.alignment {
 		r.alignment = max
 		r.alignToLastLine = max == last
 	}
-	sb.Reset()
 
-	r.p.Write(&sb, val)
+	r.pairs = append(
+		r.pairs,
+		mapPair{
+			KeyWidth: last,
+			Key:      ks,
+			Value:    vs,
+		},
+	)
+}
 
-	vs := sb.String()
+// Print prints all map key-value pairs collected by Add() method. It sorts the
+// pairs by the key strings before writing the output to the printer.
+//
+// TODO(jmalloc): sort numerically-keyed maps numerically
+func (r *mapRenderer) Print(w io.Writer) {
+	r.finalize()
 
-	r.items = append(
-		r.items,
-		mapItem{
-			keyString:   ks,
-			keyWidth:    last,
-			valueString: vs,
+	if r.Map.IsAmbiguousType() {
+		must.WriteString(w, r.Printer.FormatTypeName(r.Map))
+	}
+
+	if len(r.pairs) == 0 {
+		must.WriteString(w, "{}")
+		return
+	}
+
+	must.WriteString(w, "{\n")
+
+	indenter := indent.NewIndenter(w, r.Indent)
+	for _, p := range r.pairs {
+		p.Write(indenter, r.alignment)
+	}
+
+	must.WriteString(w, "}")
+}
+
+// finalize prepares the pairs to be rendered.
+//
+// Add() must not be called after finalize().
+func (r *mapRenderer) finalize() {
+	// compensate for the ":" added to the last line
+	if !r.alignToLastLine {
+		r.alignment--
+	}
+
+	// sort the map items by the key string
+	sort.Slice(
+		r.pairs,
+		func(i, j int) bool {
+			return r.pairs[i].Key < r.pairs[j].Key
+		},
+	)
+}
+
+// format returns the string representation of the given value, which is either
+// a key or value from the map being rendered.
+//
+// st is the v's static type (either the key type, or the value type).
+func (r *mapRenderer) format(v reflect.Value, st reflect.Type) string {
+	var w strings.Builder
+
+	r.Printer.Write(
+		&w,
+		Value{
+			Value:                  v,
+			DynamicType:            v.Type(),
+			StaticType:             st,
+			IsAmbiguousDynamicType: st.Kind() == reflect.Interface,
+			IsAmbiguousStaticType:  false,
+			IsUnexported:           r.Map.IsUnexported,
 		},
 	)
 
-	return true
-}
-
-func (r *mapRenderer) print(w io.Writer) {
-	for _, item := range r.items {
-		must.WriteString(w, item.keyString)
-		must.WriteString(w, ": ")
-
-		// align values only if the key fits in a single line
-		if !strings.ContainsRune(item.keyString, '\n') {
-			must.WriteString(w, strings.Repeat(" ", r.alignment-item.keyWidth))
-		}
-
-		must.WriteString(w, item.valueString)
-		must.WriteString(w, "\n")
-	}
+	return w.String()
 }
 
 // widths returns the number of characters in the longest, and last line of s.


### PR DESCRIPTION
This PR refactors the rendering logic in `syncmap.go` and `map.go` files to share the code wherever possible.