### PR TITLE
Add a printer configuration option to omit unexported struct fields

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -46,6 +46,9 @@ type Config struct {
 	// OmitPackagePaths, when true, causes the printer to omit the
 	// fully-qualified package path from the rendered type names.
 	OmitPackagePaths bool
+
+	// OmitUnexported omits unexported fields when set to true
+	OmitUnexported bool
 }
 
 // Printer generates human-readable representations of Go values.

--- a/printer.go
+++ b/printer.go
@@ -47,8 +47,8 @@ type Config struct {
 	// fully-qualified package path from the rendered type names.
 	OmitPackagePaths bool
 
-	// OmitUnexported omits unexported fields when set to true
-	OmitUnexported bool
+	// OmitUnexportedFields omits unexported struct fields when set to true
+	OmitUnexportedFields bool
 }
 
 // Printer generates human-readable representations of Go values.

--- a/struct.go
+++ b/struct.go
@@ -36,11 +36,11 @@ func (vis *visitor) visitStruct(w io.Writer, v Value) {
 }
 
 func (vis *visitor) visitStructFields(w io.Writer, v Value) {
-	alignment := longestFieldName(v.DynamicType, vis.config.OmitUnexported)
+	alignment := longestFieldName(v.DynamicType, vis.config.OmitUnexportedFields)
 
 	for i := 0; i < v.DynamicType.NumField(); i++ {
 		f := v.DynamicType.Field(i)
-		if vis.config.OmitUnexported && isUnexportedField(f) {
+		if vis.config.OmitUnexportedFields && isUnexportedField(f) {
 			continue
 		}
 		fv := v.Value.Field(i)

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,6 +1,8 @@
 package dapper_test
 
 import (
+	"github.com/dogmatiq/dapper"
+	"strings"
 	"testing"
 	"unsafe"
 )
@@ -99,6 +101,29 @@ func TestPrinter_StructFieldTypes(t *testing.T) {
 		"    }",
 		"}",
 	)
+}
+
+// Verifies not exported fields in a struct are omitted when configured to do so
+func TestPrinter_StructUnexportedFieldsWithOmitUnexpoted(t *testing.T) {
+	config := dapper.DefaultPrinter.Config
+	config.OmitUnexported = true
+	printer := &dapper.Printer{Config: config}
+	writer := &strings.Builder{}
+
+	_, err := printer.Write(writer, struct {
+		notExported bool
+		Exported    bool
+	}{})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "{\n    Exported: false\n}"
+	result := writer.String()
+	if expected != result {
+		t.Errorf("Expected \n'%s' but got \n'%s'", expected, result)
+	}
 }
 
 // This test verifies that all types can be formatted when obtained from

--- a/struct_test.go
+++ b/struct_test.go
@@ -106,7 +106,7 @@ func TestPrinter_StructFieldTypes(t *testing.T) {
 // Verifies not exported fields in a struct are omitted when configured to do so
 func TestPrinter_StructUnexportedFieldsWithOmitUnexpoted(t *testing.T) {
 	config := dapper.DefaultPrinter.Config
-	config.OmitUnexported = true
+	config.OmitUnexportedFields = true
 	printer := &dapper.Printer{Config: config}
 	writer := &strings.Builder{}
 


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?
Adds a configuration option to omit printing unexported struct fields.

#### Why make this change?
I was dumping a protobuffer message and found out it has a massive data structure embedded in some unexported fields, which was slowing everything to a crawl.

#### Is there anything you are unsure about?
Could there be any other needed considerations for unexported things, other than struct fields?

#### What issues does this relate to?
