### PR TITLE
Add annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Added `Annotator` type and `Config.Annotators` configuration, to add
+  user-defined annotations to values.
+
 ## [0.5.3] - 2024-04-08
 
 ### Fixed

--- a/annotator.go
+++ b/annotator.go
@@ -1,0 +1,7 @@
+package dapper
+
+// Annotator is a function that annotates a value with additional information.
+//
+// If it returns a non-empty string, the string is rendered after the value,
+// regardless of whether the value is rendered by a filter.
+type Annotator func(Value) string

--- a/annotator_test.go
+++ b/annotator_test.go
@@ -1,0 +1,176 @@
+package dapper_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	. "github.com/dogmatiq/dapper"
+)
+
+func TestPrinter_Annotator(t *testing.T) {
+	cases := []struct {
+		Name       string
+		Value      any
+		Annotators []Annotator
+		Output     []string
+	}{
+		{
+			Name:  "empty annotation",
+			Value: 123,
+			Annotators: []Annotator{
+				func(Value) string { return "" },
+			},
+			Output: []string{
+				`int(123)`,
+			},
+		},
+		{
+			Name:  "annotated nil value",
+			Value: nil,
+			Annotators: []Annotator{
+				func(Value) string { return "this is nil" },
+			},
+			Output: []string{
+				`any(nil) <<this is nil>>`,
+			},
+		},
+		{
+			Name:  "annotated non-nil value",
+			Value: 123,
+			Annotators: []Annotator{
+				func(Value) string { return "this is not nil" },
+			},
+			Output: []string{
+				"int(123) <<this is not nil>>",
+			},
+		},
+		{
+			Name:  "multiple annotations",
+			Value: 123,
+			Annotators: []Annotator{
+				func(Value) string { return "first" },
+				func(Value) string { return "" },
+				func(Value) string { return "second" },
+			},
+			Output: []string{
+				`int(123) <<first, second>>`,
+			},
+		},
+		{
+			Name: "multiline rendered value",
+			Value: struct {
+				Value int
+			}{},
+			Annotators: []Annotator{
+				func(v Value) string {
+					if v.DynamicType.Kind() == reflect.Struct {
+						return "an anonymous struct"
+					}
+					return ""
+				},
+			},
+			Output: []string{
+				`{`,
+				`    Value: int(0)`,
+				`} <<an anonymous struct>>`,
+			},
+		},
+		{
+			Name:  "annotation of nested values",
+			Value: struct{ Value int }{},
+			Annotators: []Annotator{
+				func(v Value) string {
+					if v.DynamicType.Kind() == reflect.Struct {
+						return "outer"
+					}
+					return "inner"
+				},
+			},
+			Output: []string{
+				`{`,
+				`    Value: int(0) <<inner>>`,
+				`} <<outer>>`,
+			},
+		},
+		{
+			Name:  "annotation of value that is rendered by a filter",
+			Value: errors.New("<error>"),
+			Annotators: []Annotator{
+				func(v Value) string {
+					if v.Value.CanInterface() {
+						if _, ok := v.Value.Interface().(error); ok {
+							return "an annotated error"
+						}
+					}
+					return ""
+				},
+			},
+			Output: []string{
+				`*errors.errorString{`,
+				`    s: "<error>"`,
+				`} [<error>] <<an annotated error>>`,
+			},
+		},
+		{
+			Name: "annotation of recursion marker",
+			Value: func() any {
+				type T struct {
+					Self  *T
+					Other int
+				}
+
+				var v T
+				v.Self = &v
+
+				return &v
+			}(),
+			Annotators: []Annotator{
+				func(v Value) string {
+					if v.DynamicType.String() == "*dapper_test.T" {
+						return "a recursive value"
+					}
+					return ""
+				},
+			},
+			Output: []string{
+				`*github.com/dogmatiq/dapper_test.T{`,
+				`    Self:  <recursion> <<a recursive value>>`,
+				`    Other: 0`,
+				`} <<a recursive value>>`,
+			},
+		},
+		{
+			Name: "annotation of zero value marker",
+			Value: func() any {
+				type named struct {
+					Value int
+				}
+				return named{}
+			}(),
+			Annotators: []Annotator{
+				func(v Value) string {
+					return "a zero value"
+				},
+			},
+			Output: []string{
+				`github.com/dogmatiq/dapper_test.named{<zero>} <<a zero value>>`,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			cfg := DefaultPrinter.Config
+			cfg.Annotators = c.Annotators
+
+			testWithConfig(
+				t,
+				cfg,
+				c.Name,
+				c.Value,
+				c.Output...,
+			)
+		})
+	}
+}

--- a/renderer.go
+++ b/renderer.go
@@ -117,12 +117,32 @@ func (r *renderer) FormatValue(v Value) string {
 }
 
 func (r *renderer) WriteValue(v Value) {
+	isFilterValue := r.FilterValue != nil && r.FilterValue.Value == v.Value
+
+	if !isFilterValue {
+		var annotations []string
+		for _, annotate := range r.Configuration.Annotators {
+			if a := annotate(v); a != "" {
+				annotations = append(annotations, a)
+			}
+		}
+
+		if len(annotations) > 0 {
+			defer func() {
+				r.Print(
+					" %s%s%s",
+					r.Configuration.AnnotationPrefix,
+					strings.Join(annotations, ", "),
+					r.Configuration.AnnotationSuffix,
+				)
+			}()
+		}
+	}
+
 	if v.Value.Kind() == reflect.Invalid {
 		r.Print("any(nil)")
 		return
 	}
-
-	isFilterValue := r.FilterValue != nil && r.FilterValue.Value == v.Value
 
 	if !isFilterValue {
 		if recursive := r.enter(v); recursive {

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -15,8 +15,26 @@ func test(
 	lines ...string,
 ) {
 	t.Helper()
+	testWithConfig(
+		t,
+		DefaultPrinter.Config,
+		n,
+		v,
+		lines...,
+	)
+}
+
+func testWithConfig(
+	t *testing.T,
+	cfg Config,
+	n string,
+	v any,
+	lines ...string,
+) {
+	t.Helper()
 
 	x := strings.Join(lines, "\n")
+	p := &Printer{cfg}
 
 	t.Run(
 		n,
@@ -24,7 +42,7 @@ func test(
 			t.Helper()
 
 			var w strings.Builder
-			n, err := Write(&w, v)
+			n, err := p.Write(&w, v)
 
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the support for user-defined annotations of rendered values.

#### Why make this change?

We want to be able to provide supplemental information to the rendered values over in `dogmatiq/testkit`, so that we can disambiguate values that don't have a good human-readable representation. 

For example, it's very common to use UUIDs inside Dogma messages, but it's hard for a human to discern the meaning of an arbitrary UUID. With annotations we could essentially "name" each UUID (something like `Bob's customer ID`) to make the test output more understandable.

#### Is there anything you are unsure about?

The general format of the annotations when rendered could use some bike shedding 😛 

#### What issues does this relate to?

- dogmatiq/testkit#159
